### PR TITLE
workaround olm install issue

### DIFF
--- a/tools/csv-generator.go
+++ b/tools/csv-generator.go
@@ -309,6 +309,20 @@ func getOperatorRules() *[]rbacv1.PolicyRule {
 				"*",
 			},
 		},
+		{
+			APIGroups: []string{
+				"security.openshift.io",
+			},
+			Resources: []string{
+				"securitycontextconstraints",
+			},
+			ResourceNames: []string{
+				"anyuid",
+			},
+			Verbs: []string{
+				"use",
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
rules and serviceRules use the same user, heat-operator which is so far also
hard coded in the deploment. This make install via olm to fail on latest OCP4.4.14
and probably also 4.5.3. 

This seems to be related to the BZ https://bugzilla.redhat.com/show_bug.cgi?id=1856413 / https://bugzilla.redhat.com/show_bug.cgi?id=1855088