### PR TITLE
Use heat service user to create pods/jobs

### DIFF
--- a/deploy/crds/heat.openstack.org_heats_crd.yaml
+++ b/deploy/crds/heat.openstack.org_heats_crd.yaml
@@ -59,11 +59,15 @@ spec:
               type: string
             mysqlContainerImage:
               type: string
+            serviceAccount:
+              description: service account used to create pods
+              type: string
           required:
           - heatAPIReplicas
           - heatEngineReplicas
           - heatServicePassword
           - heatStackDomainAdminPassword
+          - serviceAccount
           type: object
         status:
           description: HeatStatus defines the observed state of Heat

--- a/deploy/crds/heat.openstack.org_v1_heat_cr.yaml
+++ b/deploy/crds/heat.openstack.org_v1_heat_cr.yaml
@@ -16,3 +16,4 @@ spec:
   heatServicePassword: heat
   heatStackDomainAdminPassword: heat
   mysqlContainerImage: docker.io/tripleomaster/centos-binary-mariadb:current-tripleo
+  serviceAccount: heat

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -66,3 +66,43 @@ rules:
   - '*'
   verbs:
   - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: heat
+  namespace: openstack
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - anyuid
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -9,3 +9,15 @@ roleRef:
   kind: Role
   name: heat-operator
   apiGroup: rbac.authorization.k8s.io
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: heat
+subjects:
+- kind: ServiceAccount
+  name: heat
+roleRef:
+  kind: Role
+  name: heat
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: heat-operator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: heat

--- a/pkg/apis/heat/v1/heat_types.go
+++ b/pkg/apis/heat/v1/heat_types.go
@@ -23,6 +23,8 @@ type HeatSpec struct {
 	HeatServicePassword          string `json:"heatServicePassword"`
 	HeatStackDomainAdminPassword string `json:"heatStackDomainAdminPassword"`
 	MysqlContainerImage          string `json:"mysqlContainerImage,omitempty"`
+	// service account used to create pods
+	ServiceAccount string `json:"serviceAccount"`
 }
 
 // HeatStatus defines the observed state of Heat

--- a/pkg/heat/dbsync.go
+++ b/pkg/heat/dbsync.go
@@ -34,7 +34,7 @@ func DbSyncJob(cr *comv1.Heat, cmName string) *batchv1.Job {
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					RestartPolicy:      "OnFailure",
-					ServiceAccountName: "heat-operator",
+					ServiceAccountName: cr.Spec.ServiceAccount,
 					Containers: []corev1.Container{
 						{
 							Name:  "heat-db-sync",

--- a/pkg/heat/deployment.go
+++ b/pkg/heat/deployment.go
@@ -29,7 +29,7 @@ func HeatAPIDeployment(cr *comv1.Heat, cmName string, configHash string) *appsv1
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: "heat-operator",
+					ServiceAccountName: cr.Spec.ServiceAccount,
 					Containers: []corev1.Container{
 						{
 							Name:  "heat-api",
@@ -79,7 +79,7 @@ func HeatEngineDeployment(cr *comv1.Heat, cmName string, configHash string) *app
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: "heat-operator",
+					ServiceAccountName: cr.Spec.ServiceAccount,
 					Containers: []corev1.Container{
 						{
 							Name:  "heat-engine",

--- a/tools/csv-generator.go
+++ b/tools/csv-generator.go
@@ -103,7 +103,7 @@ Install and configure OpenStack Heat.
 				Rules:              *rules,
 			},
 			{
-				ServiceAccountName: "heat-operator",
+				ServiceAccountName: "heat",
 				Rules:              *serviceRules,
 			},
 		},
@@ -320,6 +320,17 @@ func getServiceRules() *[]rbacv1.PolicyRule {
 			},
 			Resources: []string{
 				"pods",
+			},
+			Verbs: []string{
+				"*",
+			},
+		},
+		{
+			APIGroups: []string{
+				"batch",
+			},
+			Resources: []string{
+				"jobs",
 			},
 			Verbs: []string{
 				"*",


### PR DESCRIPTION
Right now the heat-operator user is used to create pods/jobs.
This creates a new heat user which is used to create pods/jobs.