### PR TITLE
Run pre-commit with make

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,31 @@
-ci:
-  autofix_prs: false
-  skip:
-   - 'make-manifests'
-   - 'make-generate'
-   - 'go-vet'
-   - 'golangci-lint'
-   - 'go-lint'
-   - 'make-operator-lint'
-
 repos:
 - repo: local
   hooks:
+    - id: golangci-lint
+      name: golangci-lint
+      language: golang
+      types: [go]
+      entry: make
+      args: ["golangci-lint"]
+      pass_filenames: false
+    - id: gofmt
+      name: gofmt
+      language: system
+      entry: make
+      args: ["fmt"]
+      pass_filenames: false
+    - id: govet
+      name: govet
+      language: system
+      entry: make
+      args: ["vet"]
+      pass_filenames: false
+    - id: gotidy
+      name: gotidy
+      language: system
+      entry: make
+      args: ["tidy"]
+      pass_filenames: false
     - id: make-manifests
       name: make-manifests
       language: system
@@ -30,20 +45,6 @@ repos:
       args: ['operator-lint']
       pass_filenames: false
 
-- repo: https://github.com/dnephin/pre-commit-golang
-  rev: v0.5.1
-  hooks:
-    - id: go-fmt
-      exclude: ^vendor
-    - id: go-vet
-    - id: go-mod-tidy
-    - id: go-lint
-
-- repo: https://github.com/golangci/golangci-lint
-  rev: v1.50.1
-  hooks:
-    - id: golangci-lint
-
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.4.0
   hooks:
@@ -59,7 +60,6 @@ repos:
     - id: destroyed-symlinks
     - id: check-yaml
       args: [-m]
-      exclude: "^templates/(openstackconfiggenerator|openstackcontrolplane)/.*$"
     - id: check-json
     - id: detect-private-key
     - id: end-of-file-fixer
@@ -68,7 +68,7 @@ repos:
     - id: trailing-whitespace
       exclude: ^vendor
 
-- repo: https://github.com/openstack-dev/bashate.git
+- repo: https://github.com/openstack/bashate.git
   rev: 2.1.1
   hooks:
     - id: bashate

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,15 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
+.PHONY: tidy
+tidy: vet
+	go mod tidy
+
+.PHONY: golangci-lint
+golangci-lint:
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.51.2
+	$(LOCALBIN)/golangci-lint run --fix
+
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out


### PR DESCRIPTION
Updating pre-commit hook with make. pre-commit-golang repo is no longer maintained[1]. Instead of using
unmaintained repo we can use make to run pre-commit.

[1] https://github.com/dnephin/pre-commit-golang/issues/98