### PR TITLE
Use time.Duration for timeout

### DIFF
--- a/controllers/heat_controller.go
+++ b/controllers/heat_controller.go
@@ -497,7 +497,7 @@ func (r *HeatReconciler) reconcileInit(ctx context.Context,
 		jobDef,
 		heatv1beta1.DbSyncHash,
 		instance.Spec.PreserveJobs,
-		5,
+		time.Duration(5)*time.Second,
 		dbSyncHash,
 	)
 	ctrlResult, err = dbSyncjob.DoJob(

--- a/controllers/heatapi_controller.go
+++ b/controllers/heatapi_controller.go
@@ -347,7 +347,7 @@ func (r *HeatAPIReconciler) reconcileInit(
 			PasswordSelector:   instance.Spec.PasswordSelectors.Service,
 		}
 
-		ksSvcObj := keystonev1.NewKeystoneService(ksSvcSpec, instance.Namespace, serviceLabels, 10)
+		ksSvcObj := keystonev1.NewKeystoneService(ksSvcSpec, instance.Namespace, serviceLabels, time.Duration(10)*time.Second)
 		ctrlResult, err = ksSvcObj.CreateOrPatch(ctx, helper)
 		if err != nil {
 			return ctrlResult, err
@@ -378,7 +378,7 @@ func (r *HeatAPIReconciler) reconcileInit(
 			instance.Namespace,
 			ksEndptSpec,
 			serviceLabels,
-			10)
+			time.Duration(10)*time.Second)
 		ctrlResult, err = ksEndpt.CreateOrPatch(ctx, helper)
 		if err != nil {
 			return ctrlResult, err
@@ -541,7 +541,7 @@ func (r *HeatAPIReconciler) reconcileNormal(ctx context.Context, instance *heatv
 	// Define a new Deployment object
 	depl := deployment.NewDeployment(
 		heatapi.Deployment(instance, inputHash, serviceLabels),
-		5,
+		time.Duration(5)*time.Second,
 	)
 
 	ctrlResult, err = depl.CreateOrPatch(ctx, helper)

--- a/controllers/heatengine_controller.go
+++ b/controllers/heatengine_controller.go
@@ -426,7 +426,7 @@ func (r *HeatEngineReconciler) reconcileNormal(
 
 	depl := deployment.NewDeployment(
 		heatengine.Deployment(instance, inputHash, serviceLabels),
-		5,
+		time.Duration(5)*time.Second,
 	)
 
 	ctrlResult, err = depl.CreateOrPatch(ctx, helper)


### PR DESCRIPTION
instead of int. This allows us to use more fine grained timeout value such as 0.1, and encodes the unit in the type itself.

Note the current version of lib-common and keystone-operator in go.mod contains the change in these dependent libraries.