### PR TITLE
Service account

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,75 @@
 # Build the manager binary
-FROM golang:1.18 as builder
+ARG GOLANG_BUILDER=golang:1.20
+ARG OPERATOR_BASE_IMAGE=gcr.io/distroless/static:nonroot
 
-WORKDIR /workspace
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
+FROM $GOLANG_BUILDER as builder
 
-# Copy the go source
-COPY main.go main.go
-COPY api/ api/
-COPY controllers/ controllers/
+ARG CACHITO_ENV_FILE=/remote-source/cachito.env
 
-# Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+ARG REMOTE_SOURCE=.
+ARG REMOTE_SOURCE_DIR=/remote-source
+ARG REMOTE_SOURCE_SUBDIR=
+ARG DEST_ROOT=/dest-root
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+ARG GO_BUILD_EXTRA_ARGS=
+
+COPY $REMOTE_SOURCE $REMOTE_SOURCE_DIR
+WORKDIR $REMOTE_SOURCE_DIR/$REMOTE_SOURCE_SUBDIR
+
+RUN mkdir -p ${DEST_ROOT}/usr/local/bin/
+
+
+ARG TARGETOS
+ARG TARGETARCH
+
+RUN if [ ! -f $CACHITO_ENV_FILE ]; then go mod download ; fi
+
+# Build manager
+RUN if [ -f $CACHITO_ENV_FILE ] ; then source $CACHITO_ENV_FILE ; fi ; CGO_ENABLED=0  GO111MODULE=on go build ${GO_BUILD_EXTRA_ARGS} -a -o ${DEST_ROOT}/manager main.go
+
+RUN cp -r templates ${DEST_ROOT}/templates
+
+
+FROM $OPERATOR_BASE_IMAGE
+
+ARG DEST_ROOT=/dest-root
+ARG USER_ID=65532
+
+ARG IMAGE_COMPONENT="heat-operator-container"
+ARG IMAGE_NAME="heat-operator"
+ARG IMAGE_VERSION="1.0.0"
+ARG IMAGE_SUMMARY="Heat Operator"
+ARG IMAGE_DESC="This image includes the heat-operator"
+ARG IMAGE_TAGS="cn-openstack openstack"
+
+### DO NOT EDIT LINES BELOW
+# Auto generated using CI tools from
+# https://github.com/openstack-k8s-operators/openstack-k8s-operators-ci
+
+# Labels required by upstream and osbs build system
+LABEL com.redhat.component="${IMAGE_COMPONENT}" \
+      name="${IMAGE_NAME}" \
+      version="${IMAGE_VERSION}" \
+      summary="${IMAGE_SUMMARY}" \
+      io.k8s.name="${IMAGE_NAME}" \
+      io.k8s.description="${IMAGE_DESC}" \
+      io.openshift.tags="${IMAGE_TAGS}"
+### DO NOT EDIT LINES ABOVE
+
+ENV USER_UID=$USER_ID \
+    OPERATOR_TEMPLATES=/usr/share/heat-operator/templates/
+
 WORKDIR /
-COPY --from=builder /workspace/manager .
-USER 65532:65532
+
+# Install operator binary to WORKDIR
+COPY --from=builder ${DEST_ROOT}/manager .
+
+# Install templates
+COPY --from=builder ${DEST_ROOT}/templates ${OPERATOR_TEMPLATES}
+
+USER $USER_ID
+
+ENV PATH="/:${PATH}"
 
 ENTRYPOINT ["/manager"]
+

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 # This variable is used to construct full image tags for bundle and catalog images.
 #
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
-# github.com/openstack-k8s-operators/horizon-operator-bundle:$VERSION and github.com/openstack-k8s-operators/horizon-operator-catalog:$VERSION.
-IMAGE_TAG_BASE ?= github.com/openstack-k8s-operators/horizon-operator
+# github.com/openstack-k8s-operators/heat-operator-bundle:$VERSION and github.com/openstack-k8s-operators/heat-operator-catalog:$VERSION.
+IMAGE_TAG_BASE ?= github.com/openstack-k8s-operators/heat-operator
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -1,0 +1,20 @@
+FROM scratch
+
+# Core bundle labels.
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=heat-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.27.0
+LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
+LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
+
+# Labels for testing.
+LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
+LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
+
+# Copy files to locations specified by labels.
+COPY bundle/manifests /manifests/
+COPY bundle/metadata /metadata/
+COPY bundle/tests/scorecard /tests/scorecard/

--- a/config/manifests/bases/heat-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/heat-operator.clusterserviceversion.yaml
@@ -1,0 +1,45 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: "[]"
+    capabilities: Basic Install
+  name: heat-operator.v0.0.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+      - description: heat is the Schema for the heats API
+        displayName: heat
+        kind: Heat
+        name: heats.heat.openstack.org
+        version: v1alpha1
+  description: heat operator
+  displayName: heat-operator-bundle
+  icon:
+    - base64data: ""
+      mediatype: ""
+  install:
+    spec:
+      deployments: null
+    strategy: ""
+  installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+  keywords:
+    - fkjdasf
+  links:
+    - name: heat Operator
+      url: https://heat-operator.domain
+  maturity: alpha
+  provider:
+    name: anything
+    url: fsadfl
+  version: 0.0.0

--- a/config/manifests/bases/heat-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/heat-operator.clusterserviceversion.yaml
@@ -15,6 +15,11 @@ spec:
         kind: Heat
         name: heats.heat.openstack.org
         version: v1alpha1
+      - description: Heat is the Schema for the heats API
+        displayName: Heat
+        kind: Heat
+        name: heats.heat.openstack.org
+        version: v1beta1
   description: heat operator
   displayName: heat-operator-bundle
   icon:

--- a/config/manifests/bases/heat-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/heat-operator.clusterserviceversion.yaml
@@ -4,8 +4,8 @@ metadata:
   annotations:
     alm-examples: "[]"
     capabilities: Basic Install
-  name: heat-operator.v0.0.0
-  namespace: placeholder
+  name: heat-operator.v0.0.1
+  namespace: openstack
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -6,6 +6,51 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - heat.openstack.org
   resources:
   - heatapiss
@@ -83,3 +128,30 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - keystone.openstack.org
+  resources:
+  - keystoneapis
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - keystone.openstack.org
+  resources:
+  - keystoneendpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -3,3 +3,53 @@ kind: ServiceAccount
 metadata:
   name: controller-manager
   namespace: system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: heat
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: heat-role
+  namespace: openstack
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - anyuid
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - post
+      - update
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: heat-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: heat-role
+subjects:
+  # Applying the role to both SA (with and without prefix) to be able
+  # to run the operator local
+  - kind: ServiceAccount
+    name: heat-operator-heat
+    namespace: openstack
+  - kind: ServiceAccount
+    name: heat
+    namespace: openstack

--- a/controllers/heat_controller.go
+++ b/controllers/heat_controller.go
@@ -67,6 +67,13 @@ type HeatReconciler struct {
 //+kubebuilder:rbac:groups=heat.openstack.org,resources=heatengines,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=heat.openstack.org,resources=heatengines/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=heat.openstack.org,resources=heatengines/finalizers,verbs=update
+//+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch
+//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch
+//+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch
+//+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete;
+//+kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch;create;update;patch
+//+kubebuilder:rbac:groups=keystone.openstack.org,resources=keystoneapis,verbs=get;list;watch;
+//+kubebuilder:rbac:groups=keystone.openstack.org,resources=keystoneendpoints,verbs=get;list;watch;
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/controllers/heatapi_controller.go
+++ b/controllers/heatapi_controller.go
@@ -279,12 +279,15 @@ func (r *HeatAPIReconciler) reconcileInit(
 	data := map[endpoint.Endpoint]endpoint.Data{
 		endpoint.EndpointPublic: {
 			Port: heat.HeatPublicPort,
+			Path: "/v1/%(tenant_id)s",
 		},
 		endpoint.EndpointAdmin: {
 			Port: heat.HeatAdminPort,
+			Path: "/v1/%(tenant_id)s",
 		},
 		endpoint.EndpointInternal: {
 			Port: heat.HeatInternalPort,
+			Path: "/v1/%(tenant_id)s",
 		},
 	}
 

--- a/pkg/heat/const.go
+++ b/pkg/heat/const.go
@@ -21,7 +21,7 @@ const (
 	// ServiceType -
 	ServiceType = "orchestration"
 	// ServiceAccount -
-	ServiceAccount = "heat-operator"
+	ServiceAccount = "heat-operator-heat"
 	// DatabaseName -
 	DatabaseName = "heat"
 	// HeatPublicPort -

--- a/templates/heatapi/config/heat-api-httpd.conf
+++ b/templates/heatapi/config/heat-api-httpd.conf
@@ -47,7 +47,7 @@ CustomLog /dev/stdout proxy env=forwarded
   WSGIApplicationGroup %{GLOBAL}
   WSGIDaemonProcess heat_api display-name=heat_api_wsgi group=heat processes=8 threads=1 user=heat
   WSGIProcessGroup heat_api
-  WSGIScriptAlias / "/var/www/cgi-bin/heat/heat_api"
+  WSGIScriptAlias / "/usr/bin/heat-wsgi-api"
   WSGIPassAuthorization On
 
   ## Custom fragment


### PR DESCRIPTION
This change corrects the Service Account name to align with other services.

In addition, it corrects the Endpoint URL to include the `%(tenant_id)s`:

From:
```
❯ openstack endpoint list --service heat -f yaml -c URL
- URL: http://heat-admin.openstack.svc:8004
- URL: http://heat-internal.openstack.svc:8004
- URL: http://heat-public-openstack.apps.okd.bne-shift.net
```

To:
```
❯ openstack endpoint list --service heat -f yaml -c URL
- URL: http://heat-admin.openstack.svc:8004/v1/%(tenant_id)s
- URL: http://heat-internal.openstack.svc:8004/v1/%(tenant_id)s
- URL: http://heat-public-openstack.apps.okd.bne-shift.net/v1/%(tenant_id)s
```
