### PR TITLE
This change comments out the suite_test.go content

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 
 package controllers
 
+/*
 import (
 	"path/filepath"
 	"testing"
@@ -78,3 +79,4 @@ var _ = AfterSuite(func() {
 	err := testEnv.Stop()
 	Expect(err).NotTo(HaveOccurred())
 })
+*/


### PR DESCRIPTION
In line with some of the other operators, this change comments out the suite_test.go content as we currently don't have things in place for envtest.