### PR TITLE
Pass PasswordSelectors to each service deployment

### DIFF
--- a/config/samples/heat_v1beta1_heat.yaml
+++ b/config/samples/heat_v1beta1_heat.yaml
@@ -20,7 +20,7 @@ spec:
       dbSync: false
       service: false
     passwordSelectors:
-      admin: AdminPassword
+      service: AdminPassword
       database: AdminPassword
     replicas: 1
     resources: {}
@@ -35,14 +35,14 @@ spec:
       dbSync: false
       service: false
     passwordSelectors:
-      admin: AdminPassword
+      service: AdminPassword
       database: AdminPassword
     replicas: 1
     resources: {}
     secret: "osp-secret"
     serviceUser: ""
   passwordSelectors:
-    admin: AdminPassword
+    service: AdminPassword
     database: AdminPassword
   preserveJobs: false
   secret: osp-secret

--- a/controllers/heat_controller.go
+++ b/controllers/heat_controller.go
@@ -608,6 +608,7 @@ func (r *HeatReconciler) apiDeploymentCreateOrUpdate(instance *heatv1beta1.Heat)
 		deployment.Spec.DatabaseUser = instance.Spec.DatabaseUser
 		deployment.Spec.Secret = instance.Spec.Secret
 		deployment.Spec.TransportURLSecret = instance.Status.TransportURLSecret
+		deployment.Spec.PasswordSelectors = instance.Spec.PasswordSelectors
 
 		err := controllerutil.SetControllerReference(instance, deployment, r.Scheme)
 		if err != nil {
@@ -636,6 +637,7 @@ func (r *HeatReconciler) engineDeploymentCreateOrUpdate(instance *heatv1beta1.He
 		deployment.Spec.DatabaseUser = instance.Spec.DatabaseUser
 		deployment.Spec.Secret = instance.Spec.Secret
 		deployment.Spec.TransportURLSecret = instance.Status.TransportURLSecret
+		deployment.Spec.PasswordSelectors = instance.Spec.PasswordSelectors
 
 		err := controllerutil.SetControllerReference(instance, deployment, r.Scheme)
 		if err != nil {


### PR DESCRIPTION
This change passes the PasswordSelectors from the base spec into the API and Engine specs. 

Additionally, this corrects an error with the samples file. It was incorrectly set as admin when it should have been service.