### PR TITLE
Extend timeout in golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,2 @@
+run:
+  timeout: 5m

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ tidy: vet
 .PHONY: golangci-lint
 golangci-lint:
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.51.2
-	$(LOCALBIN)/golangci-lint run --fix
+	$(LOCALBIN)/golangci-lint run --fix --verbose
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.


### PR DESCRIPTION
The command sometimes fails because of timeout (default 1m0s) in CI. Let's increase timeout to avoid frequent failure.