### PR TITLE
Replace TripleO images by TCIB images

### DIFF
--- a/api/v1beta1/heatapi_types.go
+++ b/api/v1beta1/heatapi_types.go
@@ -30,7 +30,7 @@ type HeatAPISpec struct {
 	ServiceUser string `json:"serviceUser"`
 
 	// +kubebuilder:validation:Required
-	// +kubebuilder:default="quay.io/tripleozedcentos9/openstack-heat-api:current-tripleo"
+	// +kubebuilder:default="quay.io/podified-antelope-centos9/openstack-heat-api:current-podified"
 	// ContainerImage - Heat API Container Image URL
 	ContainerImage string `json:"containerImage"`
 

--- a/api/v1beta1/heatengine_types.go
+++ b/api/v1beta1/heatengine_types.go
@@ -30,7 +30,7 @@ type HeatEngineSpec struct {
 	ServiceUser string `json:"serviceUser"`
 
 	// +kubebuilder:validation:Required
-	// +kubebuilder:default="quay.io/tripleozedcentos9/openstack-heat-engine:current-tripleo"
+	// +kubebuilder:default="quay.io/podified-antelope-centos9/openstack-heat-engine:current-podified"
 	// ContainerImage - Heat API Container Image URL
 	ContainerImage string `json:"containerImage"`
 

--- a/config/crd/bases/heat.openstack.org_heatapis.yaml
+++ b/config/crd/bases/heat.openstack.org_heatapis.yaml
@@ -36,7 +36,7 @@ spec:
             description: HeatAPISpec defines the desired state of Heat
             properties:
               containerImage:
-                default: quay.io/tripleozedcentos9/openstack-heat-api:current-tripleo
+                default: quay.io/podified-antelope-centos9/openstack-heat-api:current-podified
                 description: ContainerImage - Heat API Container Image URL
                 type: string
               customServiceConfig:

--- a/config/crd/bases/heat.openstack.org_heatengines.yaml
+++ b/config/crd/bases/heat.openstack.org_heatengines.yaml
@@ -36,7 +36,7 @@ spec:
             description: HeatEngineSpec defines the desired state of Heat
             properties:
               containerImage:
-                default: quay.io/tripleozedcentos9/openstack-heat-engine:current-tripleo
+                default: quay.io/podified-antelope-centos9/openstack-heat-engine:current-podified
                 description: ContainerImage - Heat API Container Image URL
                 type: string
               customServiceConfig:

--- a/config/crd/bases/heat.openstack.org_heats.yaml
+++ b/config/crd/bases/heat.openstack.org_heats.yaml
@@ -85,7 +85,7 @@ spec:
                   Heat deployment
                 properties:
                   containerImage:
-                    default: quay.io/tripleozedcentos9/openstack-heat-api:current-tripleo
+                    default: quay.io/podified-antelope-centos9/openstack-heat-api:current-podified
                     description: ContainerImage - Heat API Container Image URL
                     type: string
                   customServiceConfig:
@@ -228,7 +228,7 @@ spec:
                   Heat deployment
                 properties:
                   containerImage:
-                    default: quay.io/tripleozedcentos9/openstack-heat-engine:current-tripleo
+                    default: quay.io/podified-antelope-centos9/openstack-heat-engine:current-podified
                     description: ContainerImage - Heat API Container Image URL
                     type: string
                   customServiceConfig:

--- a/config/samples/heat_v1beta1_heat.yaml
+++ b/config/samples/heat_v1beta1_heat.yaml
@@ -12,7 +12,7 @@ spec:
     dbSync:
     service: false
   heatAPI:
-    containerImage: "quay.io/tripleozedcentos9/openstack-heat-api:current-tripleo"
+    containerImage: "quay.io/podified-antelope-centos9/openstack-heat-api:current-podified"
     customServiceConfig: "# add your customization here"
     databaseUser: "heat"
     debug:
@@ -27,7 +27,7 @@ spec:
     secret: "osp-secret"
     serviceUser: ""
   heatEngine:
-    containerImage: "quay.io/tripleozedcentos9/openstack-heat-engine:current-tripleo"
+    containerImage: "quay.io/podified-antelope-centos9/openstack-heat-engine:current-podified"
     customServiceConfig: "# add your customization here"
     databaseUser: "heat"
     debug:

--- a/tests/kuttl/tests/common/assert-sample-deployment.yaml
+++ b/tests/kuttl/tests/common/assert-sample-deployment.yaml
@@ -22,7 +22,7 @@ spec:
     dbSync:
     service: false
   heatAPI:
-    containerImage: "quay.io/tripleozedcentos9/openstack-heat-api:current-tripleo"
+    containerImage: "quay.io/podified-antelope-centos9/openstack-heat-api:current-podified"
     customServiceConfig: "# add your customization here"
     databaseUser: "heat"
     debug:
@@ -37,7 +37,7 @@ spec:
     secret: "osp-secret"
     serviceUser: ""
   heatEngine:
-    containerImage: "quay.io/tripleozedcentos9/openstack-heat-engine:current-tripleo"
+    containerImage: "quay.io/podified-antelope-centos9/openstack-heat-engine:current-podified"
     customServiceConfig: "# add your customization here"
     databaseUser: "heat"
     debug:
@@ -77,7 +77,7 @@ metadata:
       kind: Heat
       name: heat
 spec:
-  containerImage: quay.io/tripleozedcentos9/openstack-heat-api:current-tripleo
+  containerImage: quay.io/podified-antelope-centos9/openstack-heat-api:current-podified
   customServiceConfig: "# add your customization here"
   databaseHostname: openstack
   debug:
@@ -108,7 +108,7 @@ metadata:
       kind: Heat
       name: heat
 spec:
-  containerImage: quay.io/tripleozedcentos9/openstack-heat-api:current-tripleo
+  containerImage: quay.io/podified-antelope-centos9/openstack-heat-api:current-podified
   customServiceConfig: "# add your customization here"
   databaseHostname: openstack
   databaseUser: heat
@@ -141,7 +141,7 @@ metadata:
       kind: Heat
       name: heat
 spec:
-  containerImage: quay.io/tripleozedcentos9/openstack-heat-engine:current-tripleo
+  containerImage: quay.io/podified-antelope-centos9/openstack-heat-engine:current-podified
   customServiceConfig: "# add your customization here"
   databaseHostname: openstack
   databaseUser: heat


### PR DESCRIPTION
We imported container build tools from TripleO as TCIB[1]. Now we are retiring TripleO and should complete the migration.

[1] https://github.com/openstack-k8s-operators/tcib