### PR TITLE
Simplify heat.conf

### DIFF
--- a/templates/heat/config/heat.conf
+++ b/templates/heat/config/heat.conf
@@ -1,185 +1,40 @@
 [DEFAULT]
-# Maximum resources allowed per top-level stack. -1 stands for unlimited.
-# (integer value)
-#max_resources_per_stack = 1000
-max_resources_per_stack=1000
-# Number of times to retry when a client encounters an expected intermittent
-# error. Set to 0 to disable retries. (integer value)
-#client_retry_limit = 2
-client_retry_limit=2
-# Enables engine with convergence architecture. All stacks with this option
-# will be created using convergence engine. (boolean value)
-#convergence_engine = true
-convergence_engine=True
-# Default region name used to get services endpoints. (string value)
-#region_name_for_services = <None>
 region_name_for_services=regionOne
-# Keystone domain name which contains heat template-defined users. If
-# `stack_user_domain_id` option is set, this option is ignored. (string value)
-#stack_user_domain_name = <None>
 stack_user_domain_name = {{ .StackDomainName }}
-
-# Keystone username, a user with roles sufficient to manage users and projects
-# in the stack_user_domain. (string value)
-#stack_domain_admin = <None>
 stack_domain_admin = {{ .StackDomainAdminUsername }}
-
-# Keystone password for stack_domain_admin user. (string value)
-#stack_domain_admin_password = <None>
-
-# Maximum depth allowed when using nested stacks. (integer value)
-#max_nested_stack_depth = 5
-max_nested_stack_depth=6
-
-# Number of heat-engine processes to fork and run. Will default to either to 4
-# or number of CPUs on the host, whichever is greater. (integer value)
-#num_engine_workers = <None>
+#stack_domain_admin_password =
 num_engine_workers=4
-
-# Key used to encrypt authentication info in the database. Length of this key
-# must be 32 characters. (string value)
 auth_encryption_key = notgood but just long enough i t
-
-# Maximum raw byte size of JSON request body. Should be larger than
-# max_template_size. (integer value)
-#max_json_body_size = 1048576
-max_json_body_size=4194304
-
-# If set to true, the logging level will be set to DEBUG instead of the default
-# INFO level. (boolean value)
-# Note: This option can be changed without restarting.
-#debug = false
-debug=False
-
-# (Optional) The base directory used for relative log_file  paths. This option
-# is ignored if log_config_append is set. (string value)
-# Deprecated group/name - [DEFAULT]/logdir
-#log_dir = <None>
 log_dir=/var/log/heat
 
-# Seconds to wait for a response from a call. (integer value)
-#rpc_response_timeout = 60
-rpc_response_timeout=600
-
 [cache]
-
-# Global toggle for caching. (boolean value)
-#enabled = false
 enabled=True
-
-# Memcache servers in the format of "host:port". This is used by backends
-# dependent on Memcached.If ``dogpile.cache.memcached`` or
-# ``oslo_cache.memcache_pool`` is used and a given host refer to an IPv6 or a
-# given domain refer to IPv6 then you should prefix the given address withthe
-# address family (``inet6``) (e.g ``inet6[::1]:11211``,
-# ``inet6:[fd12:3456:789a:1::1]:11211``,
-# ``inet6:[controller-0.internalapi]:11211``). If the address family is not
-# given then these backends will use the default ``inet`` address family which
-# corresponds to IPv4 (list value)
-#memcache_servers = localhost:11211
 memcache_servers=#TODO
 
-# Global toggle for TLS usage when comunicating with the caching servers.
-# (boolean value)
-#tls_enabled = false
-tls_enabled=False
-
-[cors]
-
-# Indicate which headers are safe to expose to the API. Defaults to HTTP Simple
-# Headers. (list value)
-#expose_headers = X-Auth-Token,X-Subject-Token,X-Service-Token,X-OpenStack-Request-ID
-expose_headers=Content-Type,Cache-Control,Content-Language,Expires,Last-Modified,Pragma
-
-# Maximum cache age of CORS preflight requests. (integer value)
-#max_age = 3600
-max_age=3600
-
-# Indicate which header field names may be used during the actual request.
-# (list value)
-#allow_headers = X-Auth-Token,X-Identity-Status,X-Roles,X-Service-Catalog,X-User-Id,X-Tenant-Id,X-OpenStack-Request-ID
-allow_headers=Content-Type,Cache-Control,Content-Language,Expires,Last-Modified,Pragma,X-Auth-Token
-
-
 [database]
-
-# Maximum number of database connection retries during startup. Set to -1 to
-# specify an infinite retry count. (integer value)
-# Deprecated group/name - [DEFAULT]/sql_max_retries
-# Deprecated group/name - [DATABASE]/sql_max_retries
-#max_retries = 10
+#connection =
 max_retries=-1
-
-# Maximum retries in case of connection error or deadlock error before error is
-# raised. Set to -1 to specify an infinite retry count. (integer value)
-#db_max_retries = 20
 db_max_retries=-1
 
 [ec2authtoken]
-
-# Authentication Endpoint URI. (string value)
-#auth_uri = <None>
 auth_uri={{ .KeystonePublicURL }}/v3/ec2tokens
 
 [oslo_messaging_notifications]
-
-# The Drivers(s) to handle sending notifications. Possible values are
-# messaging, messagingv2, routing, log, test, noop (multi valued)
-# Deprecated group/name - [DEFAULT]/notification_driver
-#driver =
 driver=noop
 
-[oslo_messaging_rabbit]
-
-# Run the health check heartbeat thread through a native python thread by
-# default. If this option is equal to False then the health check heartbeat
-# will inherit the execution model from the parent process. For example if the
-# parent process has monkey patched the stdlib by using eventlet/greenlet then
-# the heartbeat will be run through a green thread. This option should be set
-# to True only for the wsgi services. (boolean value)
-#heartbeat_in_pthread = false
-heartbeat_in_pthread=False
-
-# Number of seconds after which the Rabbit broker is considered down if
-# heartbeat's keep-alive fails (0 disables heartbeat). (integer value)
-#heartbeat_timeout_threshold = 60
-heartbeat_timeout_threshold=60
-
 [oslo_middleware]
-
-# Whether the application is behind a proxy or not. This determines if the
-# middleware should parse the headers or not. (boolean value)
-#enable_proxy_headers_parsing = false
 enable_proxy_headers_parsing=True
 
 [trustee]
-
-# Authentication type to load (string value)
-# Deprecated group/name - [trustee]/auth_plugin
-#auth_type = <None>
 auth_type=password
-
-# Authentication URL (string value)
-#auth_url = <None>
 auth_url={{ .KeystonePublicURL }}
-
-# Username (string value)
-# Deprecated group/name - [trustee]/user_name
-#username = <None>
 username=heat
-
-# User's domain id (string value)
-#user_domain_id = <None>
-
-# User's domain name (string value)
-#user_domain_name = <None>
 user_domain_name=Default
+#password =
 
-[yaql]
-limit_iterators=1000
-memory_quota=100000
 [resource_finder_cache]
 caching=False
+
 [keystone_authtoken]
 www_authenticate_uri={{ .KeystonePublicURL }}
 auth_type=password
@@ -188,6 +43,7 @@ region_name=regionOne
 auth_url={{ .KeystonePublicURL }}
 username={{ .ServiceUser }}
 user_domain_name=Default
+#password =
 project_name=service
 project_domain_name=Default
 interface=internal


### PR DESCRIPTION
This simplifies the heat.conf file used by services based on the following points.

- Remove the parameter descrpitons
- Remove redundant settings which configures the service default values
- Remove tuning done in TripleO mainly to support heat usage in undercloud