### PR TITLE
Create a secret to store auth_encryption_key

### DIFF
--- a/pkg/heat/volumes.go
+++ b/pkg/heat/volumes.go
@@ -23,6 +23,7 @@ import (
 func GetVolumes(name string) []corev1.Volume {
 	var scriptsVolumeDefaultMode int32 = 0755
 	var config0640AccessMode int32 = 0640
+	var config0600AccessMode int32 = 0600
 
 	return []corev1.Volume{
 		{
@@ -53,6 +54,15 @@ func GetVolumes(name string) []corev1.Volume {
 				EmptyDir: &corev1.EmptyDirVolumeSource{Medium: ""},
 			},
 		},
+		{
+			Name: "config-data-secrets",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName:  ServiceName,
+					DefaultMode: &config0600AccessMode,
+				},
+			},
+		},
 	}
 }
 
@@ -74,6 +84,11 @@ func GetInitVolumeMounts() []corev1.VolumeMount {
 			MountPath: "/var/lib/config-data/merged",
 			ReadOnly:  false,
 		},
+		{
+			Name:      "config-data-secrets",
+			MountPath: "/var/lib/config-data/secrets",
+			ReadOnly:  true,
+		},
 	}
 
 }
@@ -90,6 +105,11 @@ func GetVolumeMounts() []corev1.VolumeMount {
 			Name:      "config-data-merged",
 			MountPath: "/var/lib/config-data/merged",
 			ReadOnly:  false,
+		},
+		{
+			Name:      "config-data-secrets",
+			MountPath: "/var/lib/config-data/secrets",
+			ReadOnly:  true,
 		},
 	}
 }

--- a/templates/heat/config/heat-engine-config.json
+++ b/templates/heat/config/heat-engine-config.json
@@ -14,6 +14,13 @@
       "merge": false,
       "preserve_properties": true,
       "perm": "0644"
+    },
+    {
+      "source": "/var/lib/config-data/secrets/heat.conf",
+      "dest": "/etc/heat/heat.conf.d/secrets.conf",
+      "merge": false,
+      "preserve_properties": true,
+      "perm": "0600"
     }
   ],
   "permissions": [

--- a/templates/heat/config/heat.conf
+++ b/templates/heat/config/heat.conf
@@ -36,10 +36,6 @@ max_nested_stack_depth=6
 #num_engine_workers = <None>
 num_engine_workers=4
 
-# Key used to encrypt authentication info in the database. Length of this key
-# must be 32 characters. (string value)
-auth_encryption_key = notgood but just long enough i t
-
 # Maximum raw byte size of JSON request body. Should be larger than
 # max_template_size. (integer value)
 #max_json_body_size = 1048576

--- a/templates/heat/config/heatapi-config.json
+++ b/templates/heat/config/heatapi-config.json
@@ -16,6 +16,13 @@
       "perm": "0644"
     },
     {
+      "source": "/var/lib/config-data/secrets/heat.conf",
+      "dest": "/etc/heat/heat.conf.d/secrets.conf",
+      "merge": false,
+      "preserve_properties": true,
+      "perm": "0600"
+    },
+    {
       "source": "/var/lib/config-data/merged/heat-api-httpd.conf",
       "dest": "/etc/httpd/conf/httpd.conf",
       "merge": false,

--- a/templates/secrets/heat.conf
+++ b/templates/secrets/heat.conf
@@ -1,0 +1,2 @@
+[DEFAULT]
+auth_encryption_key={{ .AuthEncryptionKey }}


### PR DESCRIPTION
This introduces a k8s secret to store the [DEFAULT] auth_encryption_key option. The option is rendered in a separate config file in the conf.d directory.