### PR TITLE
Remove unused bootstrap debug flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,13 @@ spec:
   databaseUser: "heat"
   rabbitMqClusterName: rabbitmq
   debug:
-    bootstrap: false
-    dbSync:
+    dbSync: false
     service: false
   heatAPI:
     containerImage: "quay.io/podified-antelope-centos9/openstack-heat-api:current-podified"
     customServiceConfig: "# add your customization here"
     databaseUser: "heat"
     debug:
-      bootstrap: false
       dbSync: false
       service: false
     passwordSelectors:
@@ -45,7 +43,6 @@ spec:
     customServiceConfig: "# add your customization here"
     databaseUser: "heat"
     debug:
-      bootstrap: false
       dbSync: false
       service: false
     passwordSelectors:
@@ -74,7 +71,6 @@ spec:
   databaseInstance: openstack
   databaseUser: heat
   debug:
-    bootstrap: false
     dbSync: false
     service: false
 ```
@@ -116,15 +112,13 @@ heat:
     databaseUser: "heat"
     rabbitMqClusterName: rabbitmq
     debug:
-      bootstrap: false
-      dbSync:
+      dbSync: false
       service: false
     heatAPI:
       containerImage: "quay.io/tripleozedcentos9/openstack-heat-api:current-tripleo"
       customServiceConfig: "# add your customization here"
       databaseUser: "heat"
       debug:
-        bootstrap: false
         dbSync: false
         service: false
       passwordSelectors:
@@ -139,7 +133,6 @@ heat:
       customServiceConfig: "# add your customization here"
       databaseUser: "heat"
       debug:
-        bootstrap: false
         dbSync: false
         service: false
       passwordSelectors:

--- a/api/v1beta1/heat_types.go
+++ b/api/v1beta1/heat_types.go
@@ -123,10 +123,6 @@ type HeatDebug struct {
 	DBSync bool `json:"dbSync,omitempty"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
-	// ReadyCount enable debug
-	Bootstrap bool `json:"bootstrap,omitempty"`
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=false
 	// Service enable debug
 	Service bool `json:"service,omitempty"`
 }

--- a/config/crd/bases/heat.openstack.org_heatapis.yaml
+++ b/config/crd/bases/heat.openstack.org_heatapis.yaml
@@ -61,10 +61,6 @@ spec:
                   an init container is used, it runs and the actual action pod gets
                   started with sleep infinity
                 properties:
-                  bootstrap:
-                    default: false
-                    description: ReadyCount enable debug
-                    type: boolean
                   dbSync:
                     default: false
                     description: DBSync enable debug

--- a/config/crd/bases/heat.openstack.org_heatengines.yaml
+++ b/config/crd/bases/heat.openstack.org_heatengines.yaml
@@ -61,10 +61,6 @@ spec:
                   an init container is used, it runs and the actual action pod gets
                   started with sleep infinity
                 properties:
-                  bootstrap:
-                    default: false
-                    description: ReadyCount enable debug
-                    type: boolean
                   dbSync:
                     default: false
                     description: DBSync enable debug

--- a/config/crd/bases/heat.openstack.org_heats.yaml
+++ b/config/crd/bases/heat.openstack.org_heats.yaml
@@ -59,10 +59,6 @@ spec:
                   an init container is used, it runs and the actual action pod gets
                   started with sleep infinity
                 properties:
-                  bootstrap:
-                    default: false
-                    description: ReadyCount enable debug
-                    type: boolean
                   dbSync:
                     default: false
                     description: DBSync enable debug
@@ -110,10 +106,6 @@ spec:
                       If an init container is used, it runs and the actual action
                       pod gets started with sleep infinity
                     properties:
-                      bootstrap:
-                        default: false
-                        description: ReadyCount enable debug
-                        type: boolean
                       dbSync:
                         default: false
                         description: DBSync enable debug
@@ -253,10 +245,6 @@ spec:
                       If an init container is used, it runs and the actual action
                       pod gets started with sleep infinity
                     properties:
-                      bootstrap:
-                        default: false
-                        description: ReadyCount enable debug
-                        type: boolean
                       dbSync:
                         default: false
                         description: DBSync enable debug

--- a/config/samples/heat_v1beta1_heat.yaml
+++ b/config/samples/heat_v1beta1_heat.yaml
@@ -8,7 +8,6 @@ spec:
   databaseUser: "heat"
   rabbitMqClusterName: rabbitmq
   debug:
-    bootstrap: false
     dbSync:
     service: false
   heatAPI:
@@ -16,7 +15,6 @@ spec:
     customServiceConfig: "# add your customization here"
     databaseUser: "heat"
     debug:
-      bootstrap: false
       dbSync: false
       service: false
     passwordSelectors:
@@ -31,7 +29,6 @@ spec:
     customServiceConfig: "# add your customization here"
     databaseUser: "heat"
     debug:
-      bootstrap: false
       dbSync: false
       service: false
     passwordSelectors:

--- a/tests/kuttl/tests/common/assert-sample-deployment.yaml
+++ b/tests/kuttl/tests/common/assert-sample-deployment.yaml
@@ -18,15 +18,13 @@ spec:
   databaseUser: "heat"
   rabbitMqClusterName: rabbitmq
   debug:
-    bootstrap: false
-    dbSync:
+    dbSync: false
     service: false
   heatAPI:
     containerImage: "quay.io/podified-antelope-centos9/openstack-heat-api:current-podified"
     customServiceConfig: "# add your customization here"
     databaseUser: "heat"
     debug:
-      bootstrap: false
       dbSync: false
       service: false
     passwordSelectors:
@@ -41,7 +39,6 @@ spec:
     customServiceConfig: "# add your customization here"
     databaseUser: "heat"
     debug:
-      bootstrap: false
       dbSync: false
       service: false
     passwordSelectors:
@@ -81,7 +78,6 @@ spec:
   customServiceConfig: "# add your customization here"
   databaseHostname: openstack
   debug:
-    bootstrap: false
     dbSync: false
     service: false
   passwordSelectors:
@@ -113,7 +109,6 @@ spec:
   databaseHostname: openstack
   databaseUser: heat
   debug:
-    bootstrap: false
     dbSync: false
     service: false
   passwordSelectors:
@@ -146,7 +141,6 @@ spec:
   databaseHostname: openstack
   databaseUser: heat
   debug:
-    bootstrap: false
     dbSync: false
     service: false
   passwordSelectors:


### PR DESCRIPTION
This is used in keystone which has a separate bootstrap command, but heat does not have a bootstrap command and dbsync is the only command we have to execute during deployment.