### PR TITLE
Remove install_yamls dependency for kuttl tests

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -19,7 +19,7 @@ kind: TestSuite
 reportFormat: JSON
 reportName: kuttl-test-heat
 namespace: openstack
-timeout: 450
+timeout: 400
 parallel: 1
 suppress:
   - events

--- a/tests/kuttl/tests/basic/01-assert.yaml
+++ b/tests/kuttl/tests/basic/01-assert.yaml
@@ -1,1 +1,1 @@
-../../common/assert-sample-deployment.yaml
+../common/assert-sample-deployment.yaml

--- a/tests/kuttl/tests/basic/01-deploy-heat.yaml
+++ b/tests/kuttl/tests/basic/01-deploy-heat.yaml
@@ -2,5 +2,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: |
-      PWD=$INSTALL_YAMLS
-      make -C $INSTALL_YAMLS heat_deploy
+      oc apply -n openstack -f ../../../../config/samples/heat_v1beta1_heat.yaml


### PR DESCRIPTION
Instead of using install_yamls targets for deploying and cleaning up ironic, use the CR sample from config/samples. This removes a possible circular dependency issue when using install_yamls to run the jobs and to run some test steps.