### PR TITLE
Disable log file and use stderr for log output

### DIFF
--- a/templates/heat/config/db-sync-config.json
+++ b/templates/heat/config/db-sync-config.json
@@ -13,12 +13,5 @@
       "owner": "heat",
       "perm": "0600"
     }
-  ],
-  "permissions": [
-    {
-      "path": "/var/log/heat",
-      "owner": "heat:heat",
-      "recurse": true
-    }
   ]
 }

--- a/templates/heat/config/heat-engine-config.json
+++ b/templates/heat/config/heat-engine-config.json
@@ -21,11 +21,6 @@
       "path": "/etc/heat/heat.conf.d",
       "owner": "heat:heat",
       "recurse": true
-    },
-    {
-      "path": "/var/log/heat",
-      "owner": "heat:heat",
-      "recurse": true
     }
   ]
 }

--- a/templates/heat/config/heat.conf
+++ b/templates/heat/config/heat.conf
@@ -5,7 +5,7 @@ stack_domain_admin = {{ .StackDomainAdminUsername }}
 #stack_domain_admin_password =
 num_engine_workers=4
 auth_encryption_key = notgood but just long enough i t
-log_dir=/var/log/heat
+use_stderr=true
 
 [cache]
 enabled=True

--- a/templates/heat/config/heatapi-config.json
+++ b/templates/heat/config/heatapi-config.json
@@ -37,11 +37,6 @@
       "recurse": true
     },
     {
-      "path": "/var/log/heat",
-      "owner": "heat:heat",
-      "recurse": true
-    },
-    {
       "path": "/etc/httpd/",
       "owner": "apache:apache",
       "recurse": true


### PR DESCRIPTION
This change disable usage of log file and make all log outputs sent to stderr. The file is created inside pod and can fill up container file system.