### PR TITLE
Remove unused transportURLSecret from heatAPI/Engine CR

### DIFF
--- a/api/v1beta1/heatapi_types.go
+++ b/api/v1beta1/heatapi_types.go
@@ -83,10 +83,6 @@ type HeatAPISpec struct {
 	// Resources - Compute Resources required by this service (Limits/Requests).
 	// https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
-
-	// +kubebuilder:validation:Optional
-	// TransportURLSecret - Secret containing RabbitMQ transportURL
-	TransportURLSecret string `json:"transportURLSecret,omitempty"`
 }
 
 // HeatAPIStatus defines the observed state of Heat

--- a/api/v1beta1/heatengine_types.go
+++ b/api/v1beta1/heatengine_types.go
@@ -83,10 +83,6 @@ type HeatEngineSpec struct {
 	// Resources - Compute Resources required by this service (Limits/Requests).
 	// https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
-
-	// +kubebuilder:validation:Optional
-	// TransportURLSecret - Secret containing RabbitMQ transportURL
-	TransportURLSecret string `json:"transportURLSecret,omitempty"`
 }
 
 // HeatEngineStatus defines the observed state of Heat

--- a/config/crd/bases/heat.openstack.org_heatapis.yaml
+++ b/config/crd/bases/heat.openstack.org_heatapis.yaml
@@ -161,9 +161,6 @@ spec:
                 description: ServiceUser - optional username used for this service
                   to register in heat
                 type: string
-              transportURLSecret:
-                description: TransportURLSecret - Secret containing RabbitMQ transportURL
-                type: string
             required:
             - containerImage
             - secret

--- a/config/crd/bases/heat.openstack.org_heatengines.yaml
+++ b/config/crd/bases/heat.openstack.org_heatengines.yaml
@@ -161,9 +161,6 @@ spec:
                 description: ServiceUser - optional username used for this service
                   to register in heat
                 type: string
-              transportURLSecret:
-                description: TransportURLSecret - Secret containing RabbitMQ transportURL
-                type: string
             required:
             - containerImage
             - secret

--- a/config/crd/bases/heat.openstack.org_heats.yaml
+++ b/config/crd/bases/heat.openstack.org_heats.yaml
@@ -208,9 +208,6 @@ spec:
                     description: ServiceUser - optional username used for this service
                       to register in heat
                     type: string
-                  transportURLSecret:
-                    description: TransportURLSecret - Secret containing RabbitMQ transportURL
-                    type: string
                 required:
                 - containerImage
                 - secret
@@ -346,9 +343,6 @@ spec:
                     default: heat
                     description: ServiceUser - optional username used for this service
                       to register in heat
-                    type: string
-                  transportURLSecret:
-                    description: TransportURLSecret - Secret containing RabbitMQ transportURL
                     type: string
                 required:
                 - containerImage

--- a/controllers/heat_controller.go
+++ b/controllers/heat_controller.go
@@ -609,7 +609,6 @@ func (r *HeatReconciler) apiDeploymentCreateOrUpdate(instance *heatv1beta1.Heat)
 		deployment.Spec.DatabaseHostname = instance.Status.DatabaseHostname
 		deployment.Spec.DatabaseUser = instance.Spec.DatabaseUser
 		deployment.Spec.Secret = instance.Spec.Secret
-		deployment.Spec.TransportURLSecret = instance.Status.TransportURLSecret
 		deployment.Spec.PasswordSelectors = instance.Spec.PasswordSelectors
 
 		err := controllerutil.SetControllerReference(instance, deployment, r.Scheme)
@@ -638,7 +637,6 @@ func (r *HeatReconciler) engineDeploymentCreateOrUpdate(instance *heatv1beta1.He
 		deployment.Spec.DatabaseHostname = instance.Status.DatabaseHostname
 		deployment.Spec.DatabaseUser = instance.Spec.DatabaseUser
 		deployment.Spec.Secret = instance.Spec.Secret
-		deployment.Spec.TransportURLSecret = instance.Status.TransportURLSecret
 		deployment.Spec.PasswordSelectors = instance.Spec.PasswordSelectors
 
 		err := controllerutil.SetControllerReference(instance, deployment, r.Scheme)

--- a/templates/heat/bin/init.sh
+++ b/templates/heat/bin/init.sh
@@ -21,9 +21,6 @@ export DBHOST=${DatabaseHost:?"Please specify a DatabaseHost variable."}
 export DBUSER=${DatabaseUser:-"heat"}
 export DBPASSWORD=${DatabasePassword:?"Please specify a DatabasePassword variable."}
 export heatPASSWORD=${HeatPassword:?"Please specify a HeatPassword variable."}
-# TODO: nova password
-#export NOVAPASSWORD=${NovaPassword:?"Please specify a NovaPassword variable."}
-# TODO: transportURL
 export TRANSPORTURL=${TransportURL:-""}
 
 export CUSTOMCONF=${CustomConf:-""}
@@ -66,7 +63,6 @@ if [ -n "$CUSTOMCONF" ]; then
 fi
 
 # set secrets
-# TODO: transportURL
 if [ -n "$TRANSPORTURL" ]; then
     crudini --set ${SVC_CFG_MERGED} DEFAULT transport_url $TRANSPORTURL
 fi
@@ -75,5 +71,3 @@ crudini --set ${SVC_CFG_MERGED} database connection mysql+pymysql://${DBUSER}:${
 crudini --set ${SVC_CFG_MERGED} keystone_authtoken password $heatPASSWORD
 crudini --set ${SVC_CFG_MERGED} DEFAULT stack_domain_admin_password $heatPASSWORD
 crudini --set ${SVC_CFG_MERGED} trustee password $heatPASSWORD
-# TODO: service token
-#crudini --set ${SVC_CFG_MERGED} service_user password $HeatPassword

--- a/tests/kuttl/tests/common/assert-sample-deployment.yaml
+++ b/tests/kuttl/tests/common/assert-sample-deployment.yaml
@@ -118,7 +118,6 @@ spec:
   resources: {}
   secret: osp-secret
   serviceUser: heat
-  transportURLSecret: rabbitmq-transport-url-heat-heat-transport
 status:
   readyCount: 1
 ---
@@ -150,7 +149,6 @@ spec:
   resources: {}
   secret: osp-secret
   serviceUser: heat
-  transportURLSecret: rabbitmq-transport-url-heat-heat-transport
 ---
 # Test the status code is correct for each endpoint
 # This test is for heat endpoints


### PR DESCRIPTION
The transportURLSecret spec is no longer used by these two CRs when we merged config file generation to the base implementation in the heat CR.

This also removes a few invalid/outdated comments in init.sh script.