### PR TITLE
Remove non-existing rpcTransport spec

### DIFF
--- a/tests/kuttl/tests/common/assert-sample-deployment.yaml
+++ b/tests/kuttl/tests/common/assert-sample-deployment.yaml
@@ -85,7 +85,6 @@ spec:
     service: HeatPassword
   replicas: 1
   resources: {}
-  rpcTransport: json-rpc
   secret: osp-secret
   serviceUser: heat
   standalone: false


### PR DESCRIPTION
This was probably imported from ironic-operator but has never been implemented in heat-operator.