### PR TITLE
Fix default IMAGE_TAG_BASE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 # This variable is used to construct full image tags for bundle and catalog images.
 #
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
-# github.com/openstack-k8s-operators/heat-operator-bundle:$VERSION and github.com/openstack-k8s-operators/heat-operator-catalog:$VERSION.
-IMAGE_TAG_BASE ?= github.com/openstack-k8s-operators/heat-operator
+# openstack.org/keystone-operator-bundle:$VERSION and openstack.org/keystone-operator-catalog:$VERSION.
+IMAGE_TAG_BASE ?= quay.io/$(USER)/heat-operator
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)


### PR DESCRIPTION
It does not make sense to try pushing images to github.com.