### PR TITLE
Stop creating admin endpoint

### DIFF
--- a/controllers/heatapi_controller.go
+++ b/controllers/heatapi_controller.go
@@ -289,10 +289,6 @@ func (r *HeatAPIReconciler) reconcileInit(
 			Port: heat.HeatPublicPort,
 			Path: "/v1/%(tenant_id)s",
 		},
-		endpoint.EndpointAdmin: {
-			Port: heat.HeatAdminPort,
-			Path: "/v1/%(tenant_id)s",
-		},
 		endpoint.EndpointInternal: {
 			Port: heat.HeatInternalPort,
 			Path: "/v1/%(tenant_id)s",

--- a/pkg/heat/const.go
+++ b/pkg/heat/const.go
@@ -30,8 +30,6 @@ const (
 	DatabaseName = "heat"
 	// HeatPublicPort -
 	HeatPublicPort int32 = 8004
-	// HeatAdminPort -
-	HeatAdminPort int32 = 8004
 	// HeatInternalPort -
 	HeatInternalPort int32 = 8004
 	// KollaConfigDbSync -


### PR DESCRIPTION
keystone-operator no longer creates admin endpoint[1]. This follows that and removing admin endpoint.

[1] https://github.com/openstack-k8s-operators/keystone-operator/pull/175