### PR TITLE
Load secret to configure auth_encryption_key

### DIFF
--- a/api/v1beta1/heat_types.go
+++ b/api/v1beta1/heat_types.go
@@ -51,10 +51,11 @@ type HeatSpec struct {
 
 	// +kubebuilder:validation:Required
 	// Secret containing OpenStack password information for heat HeatDatabasePassword, HeatPassword
+	// and HeatAuthEncryptionKey
 	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={database: HeatDatabasePassword, service: HeatPassword}
+	// +kubebuilder:default={database: HeatDatabasePassword, service: HeatPassword, authEncryptionKey: HeatAuthEncryptionKey}
 	// PasswordSelectors - Selectors to identify the DB and ServiceUser password from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
 
@@ -112,8 +113,12 @@ type PasswordSelector struct {
 	Database string `json:"database,omitempty"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="HeatPassword"
-	// Database - Selector to get the heat service password from the Secret
+	// Service - Selector to get the heat service password from the Secret
 	Service string `json:"service,omitempty"`
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default="HeatAuthEncryptionKey"
+	// AuthEncryptionKey - Selector to get the heat auth encryption key from the Secret
+	AuthEncryptionKey string `json:"authEncryptionKey,omitempty"`
 }
 
 // HeatDebug ...
@@ -139,7 +144,7 @@ type HeatStatus struct {
 	// Conditions
 	Conditions condition.Conditions `json:"conditions,omitempty" optional:"true"`
 
-	// Neutron Database Hostname
+	// Heat Database Hostname
 	DatabaseHostname string `json:"databaseHostname,omitempty"`
 
 	// ServiceID - the ID of the registered service in keystone

--- a/api/v1beta1/heatapi_types.go
+++ b/api/v1beta1/heatapi_types.go
@@ -51,10 +51,11 @@ type HeatAPISpec struct {
 
 	// +kubebuilder:validation:Required
 	// Secret containing OpenStack password information for heat HeatDatabasePassword, HeatPassword
+	// and HeatAuthEncryptionKey
 	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={database: HeatDatabasePassword, service: HeatPassword}
+	// +kubebuilder:default={database: HeatDatabasePassword, service: HeatPassword, authEncryptionKey: HeatAuthEncryptionKey}
 	// PasswordSelectors - Selectors to identify the DB and ServiceUser password from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
 

--- a/api/v1beta1/heatengine_types.go
+++ b/api/v1beta1/heatengine_types.go
@@ -51,10 +51,11 @@ type HeatEngineSpec struct {
 
 	// +kubebuilder:validation:Required
 	// Secret containing OpenStack password information for heat HeatDatabasePassword, HeatPassword
+	// and HeatAuthEncryptionKey
 	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={database: HeatDatabasePassword, service: HeatPassword}
+	// +kubebuilder:default={database: HeatDatabasePassword, service: HeatPassword, authEncryptionKey: HeatAuthEncryptionKey}
 	// PasswordSelectors - Selectors to identify the DB and ServiceUser password from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
 

--- a/config/crd/bases/heat.openstack.org_heatapis.yaml
+++ b/config/crd/bases/heat.openstack.org_heatapis.yaml
@@ -86,11 +86,17 @@ spec:
                 type: object
               passwordSelectors:
                 default:
+                  authEncryptionKey: HeatAuthEncryptionKey
                   database: HeatDatabasePassword
                   service: HeatPassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
                 properties:
+                  authEncryptionKey:
+                    default: HeatAuthEncryptionKey
+                    description: AuthEncryptionKey - Selector to get the heat auth
+                      encryption key from the Secret
+                    type: string
                   database:
                     default: heatDatabasePassword
                     description: 'Database - Selector to get the heat Database user
@@ -98,7 +104,7 @@ spec:
                     type: string
                   service:
                     default: HeatPassword
-                    description: Database - Selector to get the heat service password
+                    description: Service - Selector to get the heat service password
                       from the Secret
                     type: string
                 type: object
@@ -157,7 +163,7 @@ spec:
                 type: object
               secret:
                 description: Secret containing OpenStack password information for
-                  heat HeatDatabasePassword, HeatPassword
+                  heat HeatDatabasePassword, HeatPassword and HeatAuthEncryptionKey
                 type: string
               serviceUser:
                 default: heat

--- a/config/crd/bases/heat.openstack.org_heatengines.yaml
+++ b/config/crd/bases/heat.openstack.org_heatengines.yaml
@@ -86,11 +86,17 @@ spec:
                 type: object
               passwordSelectors:
                 default:
+                  authEncryptionKey: HeatAuthEncryptionKey
                   database: HeatDatabasePassword
                   service: HeatPassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
                 properties:
+                  authEncryptionKey:
+                    default: HeatAuthEncryptionKey
+                    description: AuthEncryptionKey - Selector to get the heat auth
+                      encryption key from the Secret
+                    type: string
                   database:
                     default: heatDatabasePassword
                     description: 'Database - Selector to get the heat Database user
@@ -98,7 +104,7 @@ spec:
                     type: string
                   service:
                     default: HeatPassword
-                    description: Database - Selector to get the heat service password
+                    description: Service - Selector to get the heat service password
                       from the Secret
                     type: string
                 type: object
@@ -157,7 +163,7 @@ spec:
                 type: object
               secret:
                 description: Secret containing OpenStack password information for
-                  heat HeatDatabasePassword, HeatPassword
+                  heat HeatDatabasePassword, HeatPassword and HeatAuthEncryptionKey
                 type: string
               serviceUser:
                 default: heat

--- a/config/crd/bases/heat.openstack.org_heats.yaml
+++ b/config/crd/bases/heat.openstack.org_heats.yaml
@@ -131,11 +131,17 @@ spec:
                     type: object
                   passwordSelectors:
                     default:
+                      authEncryptionKey: HeatAuthEncryptionKey
                       database: HeatDatabasePassword
                       service: HeatPassword
                     description: PasswordSelectors - Selectors to identify the DB
                       and ServiceUser password from the Secret
                     properties:
+                      authEncryptionKey:
+                        default: HeatAuthEncryptionKey
+                        description: AuthEncryptionKey - Selector to get the heat
+                          auth encryption key from the Secret
+                        type: string
                       database:
                         default: heatDatabasePassword
                         description: 'Database - Selector to get the heat Database
@@ -144,7 +150,7 @@ spec:
                         type: string
                       service:
                         default: HeatPassword
-                        description: Database - Selector to get the heat service password
+                        description: Service - Selector to get the heat service password
                           from the Secret
                         type: string
                     type: object
@@ -204,7 +210,7 @@ spec:
                     type: object
                   secret:
                     description: Secret containing OpenStack password information
-                      for heat HeatDatabasePassword, HeatPassword
+                      for heat HeatDatabasePassword, HeatPassword and HeatAuthEncryptionKey
                     type: string
                   serviceUser:
                     default: heat
@@ -273,11 +279,17 @@ spec:
                     type: object
                   passwordSelectors:
                     default:
+                      authEncryptionKey: HeatAuthEncryptionKey
                       database: HeatDatabasePassword
                       service: HeatPassword
                     description: PasswordSelectors - Selectors to identify the DB
                       and ServiceUser password from the Secret
                     properties:
+                      authEncryptionKey:
+                        default: HeatAuthEncryptionKey
+                        description: AuthEncryptionKey - Selector to get the heat
+                          auth encryption key from the Secret
+                        type: string
                       database:
                         default: heatDatabasePassword
                         description: 'Database - Selector to get the heat Database
@@ -286,7 +298,7 @@ spec:
                         type: string
                       service:
                         default: HeatPassword
-                        description: Database - Selector to get the heat service password
+                        description: Service - Selector to get the heat service password
                           from the Secret
                         type: string
                     type: object
@@ -346,7 +358,7 @@ spec:
                     type: object
                   secret:
                     description: Secret containing OpenStack password information
-                      for heat HeatDatabasePassword, HeatPassword
+                      for heat HeatDatabasePassword, HeatPassword and HeatAuthEncryptionKey
                     type: string
                   serviceUser:
                     default: heat
@@ -371,11 +383,17 @@ spec:
                 type: integer
               passwordSelectors:
                 default:
+                  authEncryptionKey: HeatAuthEncryptionKey
                   database: HeatDatabasePassword
                   service: HeatPassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
                 properties:
+                  authEncryptionKey:
+                    default: HeatAuthEncryptionKey
+                    description: AuthEncryptionKey - Selector to get the heat auth
+                      encryption key from the Secret
+                    type: string
                   database:
                     default: heatDatabasePassword
                     description: 'Database - Selector to get the heat Database user
@@ -383,7 +401,7 @@ spec:
                     type: string
                   service:
                     default: HeatPassword
-                    description: Database - Selector to get the heat service password
+                    description: Service - Selector to get the heat service password
                       from the Secret
                     type: string
                 type: object
@@ -399,7 +417,7 @@ spec:
                 type: string
               secret:
                 description: Secret containing OpenStack password information for
-                  heat HeatDatabasePassword, HeatPassword
+                  heat HeatDatabasePassword, HeatPassword and HeatAuthEncryptionKey
                 type: string
               serviceUser:
                 default: heat
@@ -467,7 +485,7 @@ spec:
                   type: object
                 type: array
               databaseHostname:
-                description: Neutron Database Hostname
+                description: Heat Database Hostname
                 type: string
               hash:
                 additionalProperties:

--- a/pkg/heat/dbsync.go
+++ b/pkg/heat/dbsync.go
@@ -83,14 +83,15 @@ func DBSyncJob(
 	job.Spec.Template.Spec.Volumes = GetVolumes(ServiceName)
 
 	initContainerDetails := APIDetails{
-		ContainerImage:       instance.Spec.HeatAPI.ContainerImage,
-		DatabaseHost:         instance.Status.DatabaseHostname,
-		DatabaseUser:         instance.Spec.DatabaseUser,
-		DatabaseName:         DatabaseName,
-		OSPSecret:            instance.Spec.Secret,
-		DBPasswordSelector:   instance.Spec.PasswordSelectors.Database,
-		UserPasswordSelector: instance.Spec.PasswordSelectors.Service,
-		VolumeMounts:         GetInitVolumeMounts(),
+		ContainerImage:            instance.Spec.HeatAPI.ContainerImage,
+		DatabaseHost:              instance.Status.DatabaseHostname,
+		DatabaseUser:              instance.Spec.DatabaseUser,
+		DatabaseName:              DatabaseName,
+		OSPSecret:                 instance.Spec.Secret,
+		DBPasswordSelector:        instance.Spec.PasswordSelectors.Database,
+		UserPasswordSelector:      instance.Spec.PasswordSelectors.Service,
+		AuthEncryptionKeySelector: instance.Spec.PasswordSelectors.AuthEncryptionKey,
+		VolumeMounts:              GetInitVolumeMounts(),
 	}
 	job.Spec.Template.Spec.InitContainers = InitContainer(initContainerDetails)
 

--- a/pkg/heat/initcontainer.go
+++ b/pkg/heat/initcontainer.go
@@ -23,16 +23,17 @@ import (
 
 // APIDetails ..
 type APIDetails struct {
-	ContainerImage       string
-	DatabaseHost         string
-	DatabaseUser         string
-	DatabaseName         string
-	TransportURL         string
-	OSPSecret            string
-	DBPasswordSelector   string
-	UserPasswordSelector string
-	VolumeMounts         []corev1.VolumeMount
-	Privileged           bool
+	ContainerImage            string
+	DatabaseHost              string
+	DatabaseUser              string
+	DatabaseName              string
+	TransportURL              string
+	OSPSecret                 string
+	DBPasswordSelector        string
+	UserPasswordSelector      string
+	AuthEncryptionKeySelector string
+	VolumeMounts              []corev1.VolumeMount
+	Privileged                bool
 }
 
 // InitContainerCommand is
@@ -78,6 +79,17 @@ func InitContainer(init APIDetails) []corev1.Container {
 						Name: init.OSPSecret,
 					},
 					Key: init.UserPasswordSelector,
+				},
+			},
+		},
+		{
+			Name: "AuthEncryptionKey",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: init.OSPSecret,
+					},
+					Key: init.AuthEncryptionKeySelector,
 				},
 			},
 		},

--- a/pkg/heatapi/deployment.go
+++ b/pkg/heatapi/deployment.go
@@ -145,15 +145,16 @@ func Deployment(
 	}
 
 	initContainerDetails := heat.APIDetails{
-		ContainerImage:       instance.Spec.ContainerImage,
-		DatabaseHost:         instance.Spec.DatabaseHostname,
-		DatabaseUser:         instance.Spec.DatabaseUser,
-		DatabaseName:         heat.DatabaseName,
-		OSPSecret:            instance.Spec.Secret,
-		DBPasswordSelector:   instance.Spec.PasswordSelectors.Database,
-		UserPasswordSelector: instance.Spec.PasswordSelectors.Service,
-		VolumeMounts:         GetInitVolumeMounts(),
-		TransportURL:         instance.Spec.TransportURLSecret,
+		ContainerImage:            instance.Spec.ContainerImage,
+		DatabaseHost:              instance.Spec.DatabaseHostname,
+		DatabaseUser:              instance.Spec.DatabaseUser,
+		DatabaseName:              heat.DatabaseName,
+		OSPSecret:                 instance.Spec.Secret,
+		DBPasswordSelector:        instance.Spec.PasswordSelectors.Database,
+		UserPasswordSelector:      instance.Spec.PasswordSelectors.Service,
+		AuthEncryptionKeySelector: instance.Spec.PasswordSelectors.AuthEncryptionKey,
+		VolumeMounts:              GetInitVolumeMounts(),
+		TransportURL:              instance.Spec.TransportURLSecret,
 	}
 	deployment.Spec.Template.Spec.InitContainers = heat.InitContainer(initContainerDetails)
 

--- a/pkg/heatengine/deployment.go
+++ b/pkg/heatengine/deployment.go
@@ -142,15 +142,16 @@ func Deployment(instance *heatv1beta1.HeatEngine, configHash string, labels map[
 	}
 
 	initContainerDetails := heat.APIDetails{
-		ContainerImage:       instance.Spec.ContainerImage,
-		DatabaseHost:         instance.Spec.DatabaseHostname,
-		DatabaseUser:         instance.Spec.DatabaseUser,
-		DatabaseName:         heat.DatabaseName,
-		OSPSecret:            instance.Spec.Secret,
-		DBPasswordSelector:   instance.Spec.PasswordSelectors.Database,
-		UserPasswordSelector: instance.Spec.PasswordSelectors.Service,
-		VolumeMounts:         GetInitVolumeMounts(),
-		TransportURL:         instance.Spec.TransportURLSecret,
+		ContainerImage:            instance.Spec.ContainerImage,
+		DatabaseHost:              instance.Spec.DatabaseHostname,
+		DatabaseUser:              instance.Spec.DatabaseUser,
+		DatabaseName:              heat.DatabaseName,
+		OSPSecret:                 instance.Spec.Secret,
+		DBPasswordSelector:        instance.Spec.PasswordSelectors.Database,
+		UserPasswordSelector:      instance.Spec.PasswordSelectors.Service,
+		AuthEncryptionKeySelector: instance.Spec.PasswordSelectors.AuthEncryptionKey,
+		VolumeMounts:              GetInitVolumeMounts(),
+		TransportURL:              instance.Spec.TransportURLSecret,
 	}
 	deployment.Spec.Template.Spec.InitContainers = heat.InitContainer(initContainerDetails)
 

--- a/templates/heat/bin/init.sh
+++ b/templates/heat/bin/init.sh
@@ -20,11 +20,9 @@ export DB=${DatabaseName:-"heat"}
 export DBHOST=${DatabaseHost:?"Please specify a DatabaseHost variable."}
 export DBUSER=${DatabaseUser:-"heat"}
 export DBPASSWORD=${DatabasePassword:?"Please specify a DatabasePassword variable."}
-export heatPASSWORD=${HeatPassword:?"Please specify a HeatPassword variable."}
-# TODO: nova password
-#export NOVAPASSWORD=${NovaPassword:?"Please specify a NovaPassword variable."}
-# TODO: transportURL
-export TRANSPORTURL=${TransportURL:-""}
+export PASSWORD=${HeatPassword:?"Please specify a HeatPassword variable."}
+export TRANSPORT_URL=${TransportURL:-""}
+export AUTH_ENCRYPTION_KEY=${AuthEncryptionKey:-""}
 
 export CUSTOMCONF=${CustomConf:-""}
 
@@ -66,14 +64,16 @@ if [ -n "$CUSTOMCONF" ]; then
 fi
 
 # set secrets
-# TODO: transportURL
-if [ -n "$TRANSPORTURL" ]; then
-    crudini --set ${SVC_CFG_MERGED} DEFAULT transport_url $TRANSPORTURL
+if [ -n "$TRANSPORT_URL" ]; then
+    crudini --set ${SVC_CFG_MERGED} DEFAULT transport_url $TRANSPORT_URL
+fi
+
+# set auth_encryption_key
+if [ -n "$AUTH_ENCRYPTION_KEY" ]; then
+    crudini --set ${SVC_CFG_MERGED} DEFAULT auth_encryption_key $AUTH_ENCRYPTION_KEY
 fi
 
 crudini --set ${SVC_CFG_MERGED} database connection mysql+pymysql://${DBUSER}:${DBPASSWORD}@${DBHOST}/${DB}
-crudini --set ${SVC_CFG_MERGED} keystone_authtoken password $heatPASSWORD
-crudini --set ${SVC_CFG_MERGED} DEFAULT stack_domain_admin_password $heatPASSWORD
-crudini --set ${SVC_CFG_MERGED} trustee password $heatPASSWORD
-# TODO: service token
-#crudini --set ${SVC_CFG_MERGED} service_user password $HeatPassword
+crudini --set ${SVC_CFG_MERGED} keystone_authtoken password $PASSWORD
+crudini --set ${SVC_CFG_MERGED} DEFAULT stack_domain_admin_password $PASSWORD
+crudini --set ${SVC_CFG_MERGED} trustee password $PASSWORD

--- a/templates/heat/config/heat.conf
+++ b/templates/heat/config/heat.conf
@@ -4,7 +4,7 @@ stack_user_domain_name = {{ .StackDomainName }}
 stack_domain_admin = {{ .StackDomainAdminUsername }}
 #stack_domain_admin_password =
 num_engine_workers=4
-auth_encryption_key = notgood but just long enough i t
+#auth_encryption_key =
 use_stderr=true
 
 [cache]

--- a/tests/kuttl/tests/common/assert-sample-deployment.yaml
+++ b/tests/kuttl/tests/common/assert-sample-deployment.yaml
@@ -28,6 +28,7 @@ spec:
       dbSync: false
       service: false
     passwordSelectors:
+      authEncryptionKey: HeatAuthEncryptionKey
       service: HeatPassword
       database: HeatDatabasePassword
     replicas: 1
@@ -42,6 +43,7 @@ spec:
       dbSync: false
       service: false
     passwordSelectors:
+      authEncryptionKey: HeatAuthEncryptionKey
       service: HeatPassword
       database: HeatDatabasePassword
     replicas: 1
@@ -49,6 +51,7 @@ spec:
     secret: "osp-secret"
     serviceUser: ""
   passwordSelectors:
+    authEncryptionKey: HeatAuthEncryptionKey
     service: HeatPassword
     database: HeatDatabasePassword
   preserveJobs: false
@@ -81,6 +84,7 @@ spec:
     dbSync: false
     service: false
   passwordSelectors:
+    authEncryptionKey: HeatAuthEncryptionKey
     database: HeatDatabasePassword
     service: HeatPassword
   replicas: 1
@@ -111,6 +115,7 @@ spec:
     dbSync: false
     service: false
   passwordSelectors:
+    authEncryptionKey: HeatAuthEncryptionKey
     database: HeatDatabasePassword
     service: HeatPassword
   replicas: 1
@@ -143,6 +148,7 @@ spec:
     dbSync: false
     service: false
   passwordSelectors:
+    authEncryptionKey: HeatAuthEncryptionKey
     database: HeatDatabasePassword
     service: HeatPassword
   replicas: 1


### PR DESCRIPTION
This makes the [DEFAULT] auth_encryption_key option configurable, via the global OSP secret. The secret should not be rotated once stack resources are created, otherwise users are no longer able to manipulate stacks with encrypted data.