### PR TITLE
Fix typos in template parameters

### DIFF
--- a/controllers/heat_controller.go
+++ b/controllers/heat_controller.go
@@ -690,8 +690,8 @@ func (r *HeatReconciler) generateServiceConfigMaps(
 	templateParameters := map[string]interface{}{
 		"KeystonePublicURL":        authURL,
 		"ServiceUser":              instance.Spec.ServiceUser,
-		"StackdomainAdminUsername": heat.StackDomainAdminUsername,
-		"StackdomainName":          heat.StackDomainName,
+		"StackDomainAdminUsername": heat.StackDomainAdminUsername,
+		"StackDomainName":          heat.StackDomainName,
 	}
 
 	cms := []util.Template{


### PR DESCRIPTION
This fixes a few typos in template parameter names which are causing wrong values rendered in heat.conf.

```
$ oc describe cm/heat-config-data
...
heat.conf:
----
[DEFAULT]
region_name_for_services=regionOne
stack_user_domain_name = <no value>
stack_domain_admin = <no value>
...
```