### PR TITLE
Remove generic TODOs

### DIFF
--- a/controllers/heat_controller.go
+++ b/controllers/heat_controller.go
@@ -80,10 +80,6 @@ type HeatReconciler struct {
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
-// the Heat object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
 //
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.12.2/pkg/reconcile

--- a/controllers/heatapi_controller.go
+++ b/controllers/heatapi_controller.go
@@ -104,10 +104,6 @@ var (
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
-// the Heat object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
 //
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.12.2/pkg/reconcile

--- a/controllers/heatengine_controller.go
+++ b/controllers/heatengine_controller.go
@@ -70,17 +70,11 @@ type HeatEngineReconciler struct {
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
-// the Heat object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
 //
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.12.2/pkg/reconcile
 func (r *HeatEngineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = log.FromContext(ctx)
-
-	// TODO(user): your logic here
 
 	instance := &heatv1beta1.HeatEngine{}
 


### PR DESCRIPTION
Kubebuilder / operator-sdk leaves generic TODO's to provide instructions while building the operator. These aren't necessary now, so this change is cleaning up some of those generics. Specifically `TODO(user)`