### PR TITLE
Ensure status is updated correctly after reconcile

### DIFF
--- a/controllers/heatapi_controller.go
+++ b/controllers/heatapi_controller.go
@@ -564,9 +564,22 @@ func (r *HeatAPIReconciler) reconcileNormal(ctx context.Context, instance *heatv
 			condition.DeploymentReadyRunningMessage))
 		return ctrlResult, nil
 	}
-	instance.Status.ReadyCount = depl.GetDeployment().Status.ReadyReplicas
-	if instance.Status.ReadyCount > 0 {
-		instance.Status.Conditions.MarkTrue(condition.DeploymentReadyCondition, condition.DeploymentReadyMessage)
+
+	_, err = controllerutil.CreateOrPatch(context.TODO(), r.Client, instance, func() error {
+
+		instance.Status.ReadyCount = depl.GetDeployment().Status.ReadyReplicas
+		if instance.Status.ReadyCount > 0 {
+			instance.Status.Conditions.MarkTrue(condition.DeploymentReadyCondition, condition.DeploymentReadyMessage)
+		}
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return ctrl.Result{}, err
 	}
 	// create Deployment - end
 

--- a/controllers/heatengine_controller.go
+++ b/controllers/heatengine_controller.go
@@ -391,9 +391,21 @@ func (r *HeatEngineReconciler) reconcileNormal(
 			condition.DeploymentReadyRunningMessage))
 		return ctrlResult, nil
 	}
-	instance.Status.ReadyCount = depl.GetDeployment().Status.ReadyReplicas
-	if instance.Status.ReadyCount > 0 {
-		instance.Status.Conditions.MarkTrue(condition.DeploymentReadyCondition, condition.DeploymentReadyMessage)
+
+	_, err = controllerutil.CreateOrPatch(context.TODO(), r.Client, instance, func() error {
+
+		instance.Status.ReadyCount = depl.GetDeployment().Status.ReadyReplicas
+		if instance.Status.ReadyCount > 0 {
+			instance.Status.Conditions.MarkTrue(condition.DeploymentReadyCondition, condition.DeploymentReadyMessage)
+		}
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		return ctrl.Result{}, err
 	}
 
 	r.Log.Info("Reconciled Engine successfully")


### PR DESCRIPTION
We currently missing updating the status field of the CR once the resources are reconciled. This patch adds the required update.