### PR TITLE
Ensure HeatAPI/Engine CR is patched after reconciliation

### DIFF
--- a/controllers/heatapi_controller.go
+++ b/controllers/heatapi_controller.go
@@ -107,7 +107,7 @@ var (
 //
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.12.2/pkg/reconcile
-func (r *HeatAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *HeatAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, _err error) {
 	_ = log.FromContext(ctx)
 
 	// TODO(bshephar): your logic here
@@ -166,11 +166,10 @@ func (r *HeatAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			instance.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
 		}
 
-		if err := helper.SetAfter(instance); err != nil {
-			patch := client.MergeFrom(helper.GetBeforeObject())
-			if err := r.Status().Patch(ctx, instance, patch); err != nil && !k8s_errors.IsNotFound(err) {
-				util.LogErrorForObject(helper, err, "Update Status", instance)
-			}
+		err := helper.PatchInstance(ctx, instance)
+		if err != nil {
+			_err = err
+			return
 		}
 	}()
 


### PR DESCRIPTION
Currently statuses of these CRs are not updated even after reconciler completes. This fixes that problem and ensures CRs are patched.