### PR TITLE
Amend some fields heat kuttl tests

### DIFF
--- a/tests/kuttl/common/assert-sample-deployment.yaml
+++ b/tests/kuttl/common/assert-sample-deployment.yaml
@@ -59,39 +59,9 @@ spec:
   serviceUser: "heat"
 status:
   databaseHostname: openstack
-  heatAPIReadyCount: 1
-  heatConductorReadyCount:
-    null_conductor_group_null: 1
----
-apiVersion: heat.openstack.org/v1beta1
-kind: HeatAPI
-metadata:
-  finalizers:
-    - HeatAPI
-  name: heat-api
-  namespace: openstack
-  ownerReferences:
-    - apiVersion: heat.openstack.org/v1beta1
-      blockOwnerDeletion: true
-      controller: true
-      kind: Heat
-      name: heat
-spec:
-  containerImage: quay.io/podified-antelope-centos9/openstack-heat-api:current-podified
-  customServiceConfig: "# add your customization here"
-  databaseHostname: openstack
-  debug:
-    dbSync: false
-    service: false
-  passwordSelectors:
-    authEncryptionKey: HeatAuthEncryptionKey
-    database: HeatDatabasePassword
-    service: HeatPassword
-  replicas: 1
-  resources: {}
-  secret: osp-secret
-  serviceUser: heat
-  standalone: false
+  heatApiReadyCount: 1
+  heatEngineReadyCount: 1
+  transportURLSecret: rabbitmq-transport-url-heat-heat-transport
 ---
 apiVersion: heat.openstack.org/v1beta1
 kind: HeatAPI
@@ -156,19 +126,20 @@ spec:
   secret: osp-secret
   serviceUser: heat
   transportURLSecret: rabbitmq-transport-url-heat-heat-transport
+status:
+  readyCount: 1
 ---
 # Test the status code is correct for each endpoint
 # This test is for heat endpoints
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-namespaced: true
 commands:
   - script: |
       set -x
       RETURN_CODE=0
-      PUBLIC_URL=$(oc get route heat-public -o jsonpath='{.status.ingress[0].host}')
-      STATUSCODE=$(curl --silent --output /dev/stderr --head --write-out "%{http_code}" $PUBLIC_URL)
-      if test $STATUSCODE -ne 200; then
+      PUBLIC_URL=$(oc get route -n $NAMESPACE heat-public -o jsonpath='{.status.ingress[0].host}')
+      STATUSCODE=$(curl --silent --output /dev/stderr --head --write-out "%{http_code}" $PUBLIC_URL/healthcheck)
+      if test $STATUSCODE -ne 204; then
           RETURN_CODE=1
           echo "${PUBLIC_URL} status code expected is 200 but was ${STATUSCODE}"
       fi

--- a/tests/kuttl/tests/basic/01-assert.yaml
+++ b/tests/kuttl/tests/basic/01-assert.yaml
@@ -1,1 +1,1 @@
-../common/assert-sample-deployment.yaml
+../../common/assert-sample-deployment.yaml


### PR DESCRIPTION
Some fields in the assert when running the kuttl tests and are causing
them to fail. This change also modifies the directory structure of the
kuttl tests, bringing the common folder one level up, otherwise kuttl
sees it as another test case.
