### PR TITLE
Remove makefile test target from Github action

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -22,8 +22,6 @@ jobs:
         run: ./openstack-k8s-operators-ci/test-runner/govet.sh
       - name: Run golint.sh
         run: ./openstack-k8s-operators-ci/test-runner/golint.sh
-      - name: Run tests
-        run: make test
 
   golangci:
     name: github (golangci)


### PR DESCRIPTION
We will run the test target in Prow as defined by this PR: https://github.com/openshift/release/pull/39453

Thus it is not necessary to duplicate this test execution in Github actions here.