### PR TITLE
Fix typo in default database Secret key

### DIFF
--- a/api/v1beta1/heat_types.go
+++ b/api/v1beta1/heat_types.go
@@ -119,7 +119,7 @@ type HeatSpec struct {
 // PasswordSelector ..
 type PasswordSelector struct {
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="heatDatabasePassword"
+	// +kubebuilder:default="HeatDatabasePassword"
 	// Database - Selector to get the heat Database user password from the Secret
 	// TODO: not used, need change in mariadb-operator
 	Database string `json:"database,omitempty"`

--- a/config/crd/bases/heat.openstack.org_heatapis.yaml
+++ b/config/crd/bases/heat.openstack.org_heatapis.yaml
@@ -97,7 +97,7 @@ spec:
                       encryption key from the Secret
                     type: string
                   database:
-                    default: heatDatabasePassword
+                    default: HeatDatabasePassword
                     description: 'Database - Selector to get the heat Database user
                       password from the Secret TODO: not used, need change in mariadb-operator'
                     type: string

--- a/config/crd/bases/heat.openstack.org_heatcfnapis.yaml
+++ b/config/crd/bases/heat.openstack.org_heatcfnapis.yaml
@@ -96,7 +96,7 @@ spec:
                       encryption key from the Secret
                     type: string
                   database:
-                    default: heatDatabasePassword
+                    default: HeatDatabasePassword
                     description: 'Database - Selector to get the heat Database user
                       password from the Secret TODO: not used, need change in mariadb-operator'
                     type: string

--- a/config/crd/bases/heat.openstack.org_heatengines.yaml
+++ b/config/crd/bases/heat.openstack.org_heatengines.yaml
@@ -97,7 +97,7 @@ spec:
                       encryption key from the Secret
                     type: string
                   database:
-                    default: heatDatabasePassword
+                    default: HeatDatabasePassword
                     description: 'Database - Selector to get the heat Database user
                       password from the Secret TODO: not used, need change in mariadb-operator'
                     type: string

--- a/config/crd/bases/heat.openstack.org_heats.yaml
+++ b/config/crd/bases/heat.openstack.org_heats.yaml
@@ -142,7 +142,7 @@ spec:
                           auth encryption key from the Secret
                         type: string
                       database:
-                        default: heatDatabasePassword
+                        default: HeatDatabasePassword
                         description: 'Database - Selector to get the heat Database
                           user password from the Secret TODO: not used, need change
                           in mariadb-operator'
@@ -290,7 +290,7 @@ spec:
                           auth encryption key from the Secret
                         type: string
                       database:
-                        default: heatDatabasePassword
+                        default: HeatDatabasePassword
                         description: 'Database - Selector to get the heat Database
                           user password from the Secret TODO: not used, need change
                           in mariadb-operator'
@@ -439,7 +439,7 @@ spec:
                           auth encryption key from the Secret
                         type: string
                       database:
-                        default: heatDatabasePassword
+                        default: HeatDatabasePassword
                         description: 'Database - Selector to get the heat Database
                           user password from the Secret TODO: not used, need change
                           in mariadb-operator'
@@ -545,7 +545,7 @@ spec:
                       encryption key from the Secret
                     type: string
                   database:
-                    default: heatDatabasePassword
+                    default: HeatDatabasePassword
                     description: 'Database - Selector to get the heat Database user
                       password from the Secret TODO: not used, need change in mariadb-operator'
                     type: string


### PR DESCRIPTION
The first character should be upper-case to be consistent with the other keys.