### PR TITLE
Remove spec keys copied from Heat CR

### DIFF
--- a/config/samples/heat_v1beta1_heat.yaml
+++ b/config/samples/heat_v1beta1_heat.yaml
@@ -8,50 +8,32 @@ spec:
   databaseUser: "heat"
   rabbitMqClusterName: rabbitmq
   debug:
-    dbSync:
+    dbSync: false
     service: false
   heatAPI:
     containerImage: "quay.io/podified-antelope-centos9/openstack-heat-api:current-podified"
     customServiceConfig: "# add your customization here"
-    databaseUser: "heat"
     debug:
       dbSync: false
       service: false
-    passwordSelectors:
-      service: HeatPassword
-      database: HeatDatabasePassword
     replicas: 1
     resources: {}
-    secret: "osp-secret"
-    serviceUser: ""
   heatCfnAPI:
     containerImage: "quay.io/podified-antelope-centos9/openstack-heat-api-cfn:current-podified"
     customServiceConfig: "# add your customization here"
-    databaseUser: "heat"
     debug:
       dbSync: false
       service: false
-    passwordSelectors:
-      service: HeatPassword
-      database: HeatDatabasePassword
     replicas: 1
     resources: {}
-    secret: "osp-secret"
-    serviceUser: ""
   heatEngine:
     containerImage: "quay.io/podified-antelope-centos9/openstack-heat-engine:current-podified"
     customServiceConfig: "# add your customization here"
-    databaseUser: "heat"
     debug:
       dbSync: false
       service: false
-    passwordSelectors:
-      service: HeatPassword
-      database: HeatDatabasePassword
     replicas: 1
     resources: {}
-    secret: "osp-secret"
-    serviceUser: ""
   passwordSelectors:
     service: HeatPassword
     database: HeatDatabasePassword


### PR DESCRIPTION
Some spec keys of sub CRs(eg. HeatAPI) are overridden by the same keys of the Heat CR, so defining these keys has no effect.