### PR TITLE
Remove unused readyCount from Heat CR

### DIFF
--- a/api/v1beta1/heat_types.go
+++ b/api/v1beta1/heat_types.go
@@ -165,9 +165,6 @@ type HeatStatus struct {
 	// TransportURLSecret - Secret containing RabbitMQ transportURL
 	TransportURLSecret string `json:"transportURLSecret,omitempty"`
 
-	// ReadyCount of Heat instances
-	ReadyCount int32 `json:"readyCount,omitempty"`
-
 	// ReadyCount of Heat API instance
 	HeatAPIReadyCount int32 `json:"heatApiReadyCount,omitempty"`
 

--- a/config/crd/bases/heat.openstack.org_heats.yaml
+++ b/config/crd/bases/heat.openstack.org_heats.yaml
@@ -655,10 +655,6 @@ spec:
                 description: ReadyCount of Heat Engine instance
                 format: int32
                 type: integer
-              readyCount:
-                description: ReadyCount of Heat instances
-                format: int32
-                type: integer
               serviceIDs:
                 additionalProperties:
                   type: string

--- a/tests/functional/heat_controller_test.go
+++ b/tests/functional/heat_controller_test.go
@@ -70,7 +70,9 @@ var _ = Describe("Heat controller", func() {
 			Expect(Heat.Status.DatabaseHostname).To(Equal(""))
 			Expect(Heat.Status.TransportURLSecret).To(Equal(""))
 			Expect(Heat.Status.APIEndpoints).To(BeEmpty())
-			Expect(Heat.Status.ReadyCount).To(Equal(int32(0)))
+			Expect(Heat.Status.HeatAPIReadyCount).To(Equal(int32(0)))
+			Expect(Heat.Status.HeatCfnAPIReadyCount).To(Equal(int32(0)))
+			Expect(Heat.Status.HeatEngineReadyCount).To(Equal(int32(0)))
 		})
 
 		It("should have Unknown Conditions initialized as transporturl not created", func() {


### PR DESCRIPTION
This status is not used because we use ones specific to sub resources such as heatAPIReadyCount.