### PR TITLE
Rename spec.APIEndpoint to plural

### DIFF
--- a/api/v1beta1/heat_types.go
+++ b/api/v1beta1/heat_types.go
@@ -151,7 +151,7 @@ type HeatStatus struct {
 	Hash map[string]string `json:"hash,omitempty"`
 
 	// API endpoint
-	APIEndpoints map[string]map[string]string `json:"apiEndpoint,omitempty"`
+	APIEndpoints map[string]map[string]string `json:"apiEndpoints,omitempty"`
 
 	// Conditions
 	Conditions condition.Conditions `json:"conditions,omitempty" optional:"true"`

--- a/api/v1beta1/heatapi_types.go
+++ b/api/v1beta1/heatapi_types.go
@@ -98,7 +98,7 @@ type HeatAPIStatus struct {
 	Hash map[string]string `json:"hash,omitempty"`
 
 	// API endpoint
-	APIEndpoints map[string]map[string]string `json:"apiEndpoint,omitempty"`
+	APIEndpoints map[string]map[string]string `json:"apiEndpoints,omitempty"`
 
 	// Conditions
 	Conditions condition.Conditions `json:"conditions,omitempty" optional:"true"`

--- a/api/v1beta1/heatcfnapi_types.go
+++ b/api/v1beta1/heatcfnapi_types.go
@@ -97,7 +97,7 @@ type HeatCfnAPIStatus struct {
 	Hash map[string]string `json:"hash,omitempty"`
 
 	// API endpoint
-	APIEndpoints map[string]map[string]string `json:"apiEndpoint,omitempty"`
+	APIEndpoints map[string]map[string]string `json:"apiEndpoints,omitempty"`
 
 	// Conditions
 	Conditions condition.Conditions `json:"conditions,omitempty" optional:"true"`

--- a/config/crd/bases/heat.openstack.org_heatapis.yaml
+++ b/config/crd/bases/heat.openstack.org_heatapis.yaml
@@ -181,7 +181,7 @@ spec:
           status:
             description: HeatAPIStatus defines the observed state of Heat
             properties:
-              apiEndpoint:
+              apiEndpoints:
                 additionalProperties:
                   additionalProperties:
                     type: string

--- a/config/crd/bases/heat.openstack.org_heatcfnapis.yaml
+++ b/config/crd/bases/heat.openstack.org_heatcfnapis.yaml
@@ -180,7 +180,7 @@ spec:
           status:
             description: HeatCfnAPIStatus defines the observed state of Heat
             properties:
-              apiEndpoint:
+              apiEndpoints:
                 additionalProperties:
                   additionalProperties:
                     type: string

--- a/config/crd/bases/heat.openstack.org_heats.yaml
+++ b/config/crd/bases/heat.openstack.org_heats.yaml
@@ -585,7 +585,7 @@ spec:
           status:
             description: HeatStatus defines the observed state of Heat
             properties:
-              apiEndpoint:
+              apiEndpoints:
                 additionalProperties:
                   additionalProperties:
                     type: string


### PR DESCRIPTION
... because the field contains multiple endpoints(heat-api and heat-api-cfn, internal and public)