### PR TITLE
Remove endpoint url and keystone service id from status

### DIFF
--- a/api/v1beta1/heat_types.go
+++ b/api/v1beta1/heat_types.go
@@ -150,17 +150,11 @@ type HeatStatus struct {
 	// Map of hashes to track e.g. job status
 	Hash map[string]string `json:"hash,omitempty"`
 
-	// API endpoint
-	APIEndpoints map[string]map[string]string `json:"apiEndpoints,omitempty"`
-
 	// Conditions
 	Conditions condition.Conditions `json:"conditions,omitempty" optional:"true"`
 
 	// Heat Database Hostname
 	DatabaseHostname string `json:"databaseHostname,omitempty"`
-
-	// ServiceID - the ID of the registered service in keystone
-	ServiceIDs map[string]string `json:"serviceIDs,omitempty"`
 
 	// TransportURLSecret - Secret containing RabbitMQ transportURL
 	TransportURLSecret string `json:"transportURLSecret,omitempty"`

--- a/api/v1beta1/heatapi_types.go
+++ b/api/v1beta1/heatapi_types.go
@@ -97,14 +97,8 @@ type HeatAPIStatus struct {
 	// Map of hashes to track e.g. job status
 	Hash map[string]string `json:"hash,omitempty"`
 
-	// API endpoint
-	APIEndpoints map[string]map[string]string `json:"apiEndpoints,omitempty"`
-
 	// Conditions
 	Conditions condition.Conditions `json:"conditions,omitempty" optional:"true"`
-
-	// ServiceID - the ID of the registered service in keystone
-	ServiceIDs map[string]string `json:"serviceIDs,omitempty"`
 
 	// ReadyCount of Heat instances
 	ReadyCount int32 `json:"readyCount,omitempty"`

--- a/api/v1beta1/heatcfnapi_types.go
+++ b/api/v1beta1/heatcfnapi_types.go
@@ -96,14 +96,8 @@ type HeatCfnAPIStatus struct {
 	// Map of hashes to track e.g. job status
 	Hash map[string]string `json:"hash,omitempty"`
 
-	// API endpoint
-	APIEndpoints map[string]map[string]string `json:"apiEndpoints,omitempty"`
-
 	// Conditions
 	Conditions condition.Conditions `json:"conditions,omitempty" optional:"true"`
-
-	// ServiceID - the ID of the registered service in keystone
-	ServiceIDs map[string]string `json:"serviceIDs,omitempty"`
 
 	// ReadyCount of Heat instances
 	ReadyCount int32 `json:"readyCount,omitempty"`

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -154,35 +154,11 @@ func (in *HeatAPIStatus) DeepCopyInto(out *HeatAPIStatus) {
 			(*out)[key] = val
 		}
 	}
-	if in.APIEndpoints != nil {
-		in, out := &in.APIEndpoints, &out.APIEndpoints
-		*out = make(map[string]map[string]string, len(*in))
-		for key, val := range *in {
-			var outVal map[string]string
-			if val == nil {
-				(*out)[key] = nil
-			} else {
-				in, out := &val, &outVal
-				*out = make(map[string]string, len(*in))
-				for key, val := range *in {
-					(*out)[key] = val
-				}
-			}
-			(*out)[key] = outVal
-		}
-	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make(condition.Conditions, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
-	}
-	if in.ServiceIDs != nil {
-		in, out := &in.ServiceIDs, &out.ServiceIDs
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
 		}
 	}
 }
@@ -298,35 +274,11 @@ func (in *HeatCfnAPIStatus) DeepCopyInto(out *HeatCfnAPIStatus) {
 			(*out)[key] = val
 		}
 	}
-	if in.APIEndpoints != nil {
-		in, out := &in.APIEndpoints, &out.APIEndpoints
-		*out = make(map[string]map[string]string, len(*in))
-		for key, val := range *in {
-			var outVal map[string]string
-			if val == nil {
-				(*out)[key] = nil
-			} else {
-				in, out := &val, &outVal
-				*out = make(map[string]string, len(*in))
-				for key, val := range *in {
-					(*out)[key] = val
-				}
-			}
-			(*out)[key] = outVal
-		}
-	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make(condition.Conditions, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
-	}
-	if in.ServiceIDs != nil {
-		in, out := &in.ServiceIDs, &out.ServiceIDs
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
 		}
 	}
 }
@@ -560,35 +512,11 @@ func (in *HeatStatus) DeepCopyInto(out *HeatStatus) {
 			(*out)[key] = val
 		}
 	}
-	if in.APIEndpoints != nil {
-		in, out := &in.APIEndpoints, &out.APIEndpoints
-		*out = make(map[string]map[string]string, len(*in))
-		for key, val := range *in {
-			var outVal map[string]string
-			if val == nil {
-				(*out)[key] = nil
-			} else {
-				in, out := &val, &outVal
-				*out = make(map[string]string, len(*in))
-				for key, val := range *in {
-					(*out)[key] = val
-				}
-			}
-			(*out)[key] = outVal
-		}
-	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make(condition.Conditions, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
-	}
-	if in.ServiceIDs != nil {
-		in, out := &in.ServiceIDs, &out.ServiceIDs
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
 		}
 	}
 }

--- a/config/crd/bases/heat.openstack.org_heatapis.yaml
+++ b/config/crd/bases/heat.openstack.org_heatapis.yaml
@@ -181,13 +181,6 @@ spec:
           status:
             description: HeatAPIStatus defines the observed state of Heat
             properties:
-              apiEndpoints:
-                additionalProperties:
-                  additionalProperties:
-                    type: string
-                  type: object
-                description: API endpoint
-                type: object
               conditions:
                 description: Conditions
                 items:
@@ -240,11 +233,6 @@ spec:
                 description: ReadyCount of Heat instances
                 format: int32
                 type: integer
-              serviceIDs:
-                additionalProperties:
-                  type: string
-                description: ServiceID - the ID of the registered service in keystone
-                type: object
             type: object
         type: object
     served: true

--- a/config/crd/bases/heat.openstack.org_heatcfnapis.yaml
+++ b/config/crd/bases/heat.openstack.org_heatcfnapis.yaml
@@ -180,13 +180,6 @@ spec:
           status:
             description: HeatCfnAPIStatus defines the observed state of Heat
             properties:
-              apiEndpoints:
-                additionalProperties:
-                  additionalProperties:
-                    type: string
-                  type: object
-                description: API endpoint
-                type: object
               conditions:
                 description: Conditions
                 items:
@@ -239,11 +232,6 @@ spec:
                 description: ReadyCount of Heat instances
                 format: int32
                 type: integer
-              serviceIDs:
-                additionalProperties:
-                  type: string
-                description: ServiceID - the ID of the registered service in keystone
-                type: object
             type: object
         type: object
     served: true

--- a/config/crd/bases/heat.openstack.org_heats.yaml
+++ b/config/crd/bases/heat.openstack.org_heats.yaml
@@ -585,13 +585,6 @@ spec:
           status:
             description: HeatStatus defines the observed state of Heat
             properties:
-              apiEndpoints:
-                additionalProperties:
-                  additionalProperties:
-                    type: string
-                  type: object
-                description: API endpoint
-                type: object
               conditions:
                 description: Conditions
                 items:
@@ -655,11 +648,6 @@ spec:
                 description: ReadyCount of Heat Engine instance
                 format: int32
                 type: integer
-              serviceIDs:
-                additionalProperties:
-                  type: string
-                description: ServiceID - the ID of the registered service in keystone
-                type: object
               transportURLSecret:
                 description: TransportURLSecret - Secret containing RabbitMQ transportURL
                 type: string

--- a/controllers/heat_controller.go
+++ b/controllers/heat_controller.go
@@ -159,12 +159,6 @@ func (r *HeatReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 	if instance.Status.Hash == nil {
 		instance.Status.Hash = make(map[string]string)
 	}
-	if instance.Status.APIEndpoints == nil {
-		instance.Status.APIEndpoints = make(map[string]map[string]string)
-	}
-	if instance.Status.ServiceIDs == nil {
-		instance.Status.ServiceIDs = make(map[string]string)
-	}
 
 	// Handle service delete
 	if !instance.DeletionTimestamp.IsZero() {
@@ -430,7 +424,6 @@ func (r *HeatReconciler) reconcileNormal(ctx context.Context, instance *heatv1be
 		r.Log.Info(fmt.Sprintf("Deployment %s successfully reconciled - operation: %s", instance.Name, string(op)))
 	}
 	// Mirror HeatEngine status' ReadyCount to this parent CR
-	// instance.Status.ServiceIDs = heatEngine.Status.ServiceIDs
 	instance.Status.HeatEngineReadyCount = heatEngine.Status.ReadyCount
 
 	// Mirror HeatEngine's condition status
@@ -454,13 +447,7 @@ func (r *HeatReconciler) reconcileNormal(ctx context.Context, instance *heatv1be
 		r.Log.Info(fmt.Sprintf("Deployment %s successfully reconciled - operation: %s", instance.Name, string(op)))
 	}
 
-	// Mirror HeatAPI status' APIEndpoints, ServiceIDs and ReadyCount to this parent CR
-	for k, v := range heatAPI.Status.APIEndpoints {
-		instance.Status.APIEndpoints[k] = v
-	}
-	for k, v := range heatAPI.Status.ServiceIDs {
-		instance.Status.ServiceIDs[k] = v
-	}
+	// Mirror HeatAPI status' ReadyCount to this parent CR
 	instance.Status.HeatAPIReadyCount = heatAPI.Status.ReadyCount
 
 	// Mirror HeatAPI's condition status
@@ -484,13 +471,7 @@ func (r *HeatReconciler) reconcileNormal(ctx context.Context, instance *heatv1be
 		r.Log.Info(fmt.Sprintf("Deployment %s successfully reconciled - operation: %s", instance.Name, string(op)))
 	}
 
-	// Mirror HeatAPI status' APIEndpoints, ServiceIDs and ReadyCount to this parent CR
-	for k, v := range heatCfnAPI.Status.APIEndpoints {
-		instance.Status.APIEndpoints[k] = v
-	}
-	for k, v := range heatCfnAPI.Status.ServiceIDs {
-		instance.Status.ServiceIDs[k] = v
-	}
+	// Mirror HeatCfnAPI status' ReadyCount to this parent CR
 	instance.Status.HeatCfnAPIReadyCount = heatCfnAPI.Status.ReadyCount
 
 	// Mirror HeatCfnAPI's condition status

--- a/tests/functional/heat_controller_test.go
+++ b/tests/functional/heat_controller_test.go
@@ -69,7 +69,6 @@ var _ = Describe("Heat controller", func() {
 			Expect(Heat.Status.Hash).To(BeEmpty())
 			Expect(Heat.Status.DatabaseHostname).To(Equal(""))
 			Expect(Heat.Status.TransportURLSecret).To(Equal(""))
-			Expect(Heat.Status.APIEndpoints).To(BeEmpty())
 			Expect(Heat.Status.HeatAPIReadyCount).To(Equal(int32(0)))
 			Expect(Heat.Status.HeatCfnAPIReadyCount).To(Equal(int32(0)))
 			Expect(Heat.Status.HeatEngineReadyCount).To(Equal(int32(0)))
@@ -105,7 +104,6 @@ var _ = Describe("Heat controller", func() {
 			keystoneAPIName := th.CreateKeystoneAPI(namespace)
 			DeferCleanup(th.DeleteKeystoneAPI, keystoneAPIName)
 			keystoneAPI := th.GetKeystoneAPI(keystoneAPIName)
-			keystoneAPI.Status.APIEndpoints["internal"] = "http://keystone-internal-openstack.testing"
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Status().Update(ctx, keystoneAPI.DeepCopy())).Should(Succeed())
 			}, timeout, interval).Should(Succeed())


### PR DESCRIPTION
These items presented in CR status are not really used. Endpoints can be discovered using Keystone and we have no use case to require service id.