### PR TITLE
Make Secret optional for API, CFN and Engine

### DIFF
--- a/api/v1beta1/heatapi_types.go
+++ b/api/v1beta1/heatapi_types.go
@@ -50,7 +50,7 @@ type HeatAPISpec struct {
 	// DatabaseHostname - Heat Database Hostname
 	DatabaseHostname string `json:"databaseHostname,omitempty"`
 
-	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Optional
 	// Secret containing OpenStack password information for heat HeatDatabasePassword, HeatPassword
 	// and HeatAuthEncryptionKey
 	Secret string `json:"secret"`

--- a/api/v1beta1/heatcfnapi_types.go
+++ b/api/v1beta1/heatcfnapi_types.go
@@ -50,7 +50,7 @@ type HeatCfnAPISpec struct {
 	// DatabaseHostname - Heat Database Hostname
 	DatabaseHostname string `json:"databaseHostname,omitempty"`
 
-	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Optional
 	// Secret containing OpenStack password information for heat HeatDatabasePassword, HeatPassword
 	Secret string `json:"secret"`
 

--- a/api/v1beta1/heatengine_types.go
+++ b/api/v1beta1/heatengine_types.go
@@ -50,7 +50,7 @@ type HeatEngineSpec struct {
 	// DatabaseHostname - Heat Database Hostname
 	DatabaseHostname string `json:"databaseHostname,omitempty"`
 
-	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Optional
 	// Secret containing OpenStack password information for heat HeatDatabasePassword, HeatPassword
 	// and HeatAuthEncryptionKey
 	Secret string `json:"secret"`


### PR DESCRIPTION
We use the secret in the base level spec to define the secret for each of the above mentioned controllers. This change makes the Secret argument optional, which should prevent the webhook blocking deployments that don't explicitly define the Secret for each controller.