### PR TITLE
Add back secret keys for sub CRs

### DIFF
--- a/config/samples/heat_v1beta1_heat.yaml
+++ b/config/samples/heat_v1beta1_heat.yaml
@@ -18,6 +18,7 @@ spec:
       service: false
     replicas: 1
     resources: {}
+    secret: osp-secret
   heatCfnAPI:
     containerImage: "quay.io/podified-antelope-centos9/openstack-heat-api-cfn:current-podified"
     customServiceConfig: "# add your customization here"
@@ -26,6 +27,7 @@ spec:
       service: false
     replicas: 1
     resources: {}
+    secret: osp-secret
   heatEngine:
     containerImage: "quay.io/podified-antelope-centos9/openstack-heat-engine:current-podified"
     customServiceConfig: "# add your customization here"
@@ -34,6 +36,7 @@ spec:
       service: false
     replicas: 1
     resources: {}
+    secret: osp-secret
   passwordSelectors:
     service: HeatPassword
     database: HeatDatabasePassword

--- a/config/samples/heat_v1beta1_heat.yaml
+++ b/config/samples/heat_v1beta1_heat.yaml
@@ -37,9 +37,6 @@ spec:
     replicas: 1
     resources: {}
     secret: osp-secret
-  passwordSelectors:
-    service: HeatPassword
-    database: HeatDatabasePassword
   preserveJobs: false
   secret: osp-secret
   serviceUser: "heat"


### PR DESCRIPTION
These keys are required because we inherit definition of sub CRs. Currently this does not appear as a problem because webhook is modifying the value, but we should fix that behavior ideally and then the problem appears
    
This adds the keys back until we determine how we handle spec keys inherited from top-level CR.
