### PR TITLE
Use ready condition to determine readiness of HeatCfnAPi

### DIFF
--- a/api/v1beta1/heatcfnapi_types.go
+++ b/api/v1beta1/heatcfnapi_types.go
@@ -128,7 +128,7 @@ func init() {
 	SchemeBuilder.Register(&HeatCfnAPI{}, &HeatCfnAPIList{})
 }
 
-// IsReady ...
+// IsReady - returns true if HeatCfnAPI is reconciled successfully
 func (instance HeatCfnAPI) IsReady() bool {
-	return instance.Status.ReadyCount >= 1
+	return instance.Status.Conditions.IsTrue(condition.ReadyCondition)
 }


### PR DESCRIPTION
We updated the logic in HeatAPI and HeatEngine by [1] but HeatCfnAPI was not covered by that change.

[1] f3a97a1678dd585c73b6453e5e3c539084f22ce3