### PR TITLE
Use heat-engine image to run db sync

### DIFF
--- a/pkg/heat/dbsync.go
+++ b/pkg/heat/dbsync.go
@@ -67,7 +67,7 @@ func DBSyncJob(
 								"/bin/bash",
 							},
 							Args:  args,
-							Image: instance.Spec.HeatAPI.ContainerImage,
+							Image: instance.Spec.HeatEngine.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: &runAsUser,
 							},


### PR DESCRIPTION
The heat-manage command should be executed at a node with heat-engine, instead of heat-api.