### PR TITLE
Fix selector in affinity policy

### DIFF
--- a/pkg/heatapi/deployment.go
+++ b/pkg/heatapi/deployment.go
@@ -89,10 +89,11 @@ func Deployment(
 
 	// Default oslo.service graceful_shutdown_timeout is 60, so align with that
 	terminationGracePeriod := int64(60)
+	serviceName := fmt.Sprintf("%s-%s", heat.ServiceName, heat.APIComponent)
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      ServiceName,
+			Name:      instance.Name,
 			Namespace: instance.Namespace,
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -108,7 +109,7 @@ func Deployment(
 					ServiceAccountName: heat.ServiceAccount,
 					Containers: []corev1.Container{
 						{
-							Name: heat.ServiceName + "-" + heat.APIComponent,
+							Name: serviceName,
 							Command: []string{
 								"/bin/bash",
 							},
@@ -136,7 +137,7 @@ func Deployment(
 	deployment.Spec.Template.Spec.Affinity = affinity.DistributePods(
 		common.AppSelector,
 		[]string{
-			heat.ServiceName,
+			serviceName,
 		},
 		corev1.LabelHostname,
 	)

--- a/pkg/heatcfnapi/deployment.go
+++ b/pkg/heatcfnapi/deployment.go
@@ -89,10 +89,11 @@ func Deployment(
 
 	// Default oslo.service graceful_shutdown_timeout is 60, so align with that
 	terminationGracePeriod := int64(60)
+	serviceName := fmt.Sprintf("%s-%s", heat.ServiceName, heat.CfnAPIComponent)
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      ServiceName,
+			Name:      instance.Name,
 			Namespace: instance.Namespace,
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -108,7 +109,7 @@ func Deployment(
 					ServiceAccountName: heat.ServiceAccount,
 					Containers: []corev1.Container{
 						{
-							Name: heat.ServiceName + "-" + heat.CfnAPIComponent,
+							Name: serviceName,
 							Command: []string{
 								"/bin/bash",
 							},
@@ -136,7 +137,7 @@ func Deployment(
 	deployment.Spec.Template.Spec.Affinity = affinity.DistributePods(
 		common.AppSelector,
 		[]string{
-			heat.ServiceName,
+			serviceName,
 		},
 		corev1.LabelHostname,
 	)

--- a/pkg/heatengine/deployment.go
+++ b/pkg/heatengine/deployment.go
@@ -86,10 +86,11 @@ func Deployment(instance *heatv1beta1.HeatEngine, configHash string, labels map[
 
 	// Default oslo.service graceful_shutdown_timeout is 60, so align with that
 	terminationGracePeriod := int64(60)
+	serviceName := fmt.Sprintf("%s-%s", heat.ServiceName, heat.EngineComponent)
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", heat.ServiceName, heat.EngineComponent),
+			Name:      instance.Name,
 			Namespace: instance.Namespace,
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -105,7 +106,7 @@ func Deployment(instance *heatv1beta1.HeatEngine, configHash string, labels map[
 					ServiceAccountName: heat.ServiceAccount,
 					Containers: []corev1.Container{
 						{
-							Name: fmt.Sprintf("%s-%s", heat.ServiceName, heat.EngineComponent),
+							Name: serviceName,
 							Command: []string{
 								"/bin/bash",
 							},
@@ -133,7 +134,7 @@ func Deployment(instance *heatv1beta1.HeatEngine, configHash string, labels map[
 	deployment.Spec.Template.Spec.Affinity = affinity.DistributePods(
 		common.AppSelector,
 		[]string{
-			heat.ServiceName,
+			serviceName,
 		},
 		corev1.LabelHostname,
 	)


### PR DESCRIPTION
Currently we use the same name in the affinity policies to distribute pods, but this is wrong and we don't have to allocate pod for different components in different nodes. This fixes the selector and ensures we use the different name for each component.

In addition, deployment name is now determined based on CR instance name, otherwise two instances can create two deployments with the same name,