### PR TITLE
Fix selector in affinity policy

### DIFF
--- a/controllers/heatapi_controller.go
+++ b/controllers/heatapi_controller.go
@@ -497,8 +497,7 @@ func (r *HeatAPIReconciler) reconcileNormal(ctx context.Context, instance *heatv
 	//
 
 	serviceLabels := map[string]string{
-		common.AppSelector:     heat.ServiceName,
-		heat.ComponentSelector: heat.APIComponent,
+		common.AppSelector: fmt.Sprintf("%s-%s", heat.ServiceName, heat.APIComponent),
 	}
 
 	// Handle service init

--- a/controllers/heatcfnapi_controller.go
+++ b/controllers/heatcfnapi_controller.go
@@ -499,8 +499,7 @@ func (r *HeatCfnAPIReconciler) reconcileNormal(ctx context.Context, instance *he
 	//
 
 	serviceLabels := map[string]string{
-		common.AppSelector:     heat.ServiceName,
-		heat.ComponentSelector: heat.APIComponent,
+		common.AppSelector: fmt.Sprintf("%s-%s", heat.ServiceName, heat.CfnAPIComponent),
 	}
 
 	// Handle service init

--- a/controllers/heatengine_controller.go
+++ b/controllers/heatengine_controller.go
@@ -346,8 +346,7 @@ func (r *HeatEngineReconciler) reconcileNormal(
 	// Create ConfigMaps and Secrets - endv
 
 	serviceLabels := map[string]string{
-		common.AppSelector:     heat.ServiceName,
-		heat.ComponentSelector: heat.APIComponent,
+		common.AppSelector: fmt.Sprintf("%s-%s", heat.ServiceName, heat.EngineComponent),
 	}
 
 	// Handle service init

--- a/pkg/heat/const.go
+++ b/pkg/heat/const.go
@@ -42,8 +42,6 @@ const (
 	HeatCfnInternalPort int32 = 8000
 	// KollaConfigDbSync -
 	KollaConfigDbSync = "/var/lib/config-data/merged/db-sync-config.json"
-	// ComponentSelector - used by operators to specify pod labels
-	ComponentSelector = "component"
 	// APIComponent -
 	APIComponent = "api"
 	// CfnAPIComponent -

--- a/pkg/heatapi/deployment.go
+++ b/pkg/heatapi/deployment.go
@@ -16,6 +16,8 @@ limitations under the License.
 package heatapi
 
 import (
+	"fmt"
+
 	heatv1beta1 "github.com/openstack-k8s-operators/heat-operator/api/v1beta1"
 	heat "github.com/openstack-k8s-operators/heat-operator/pkg/heat"
 	common "github.com/openstack-k8s-operators/lib-common/modules/common"
@@ -89,10 +91,11 @@ func Deployment(
 
 	// Default oslo.service graceful_shutdown_timeout is 60, so align with that
 	terminationGracePeriod := int64(60)
+	serviceName := fmt.Sprintf("%s-%s", heat.ServiceName, heat.APIComponent)
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      ServiceName,
+			Name:      serviceName,
 			Namespace: instance.Namespace,
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -108,7 +111,7 @@ func Deployment(
 					ServiceAccountName: heat.ServiceAccount,
 					Containers: []corev1.Container{
 						{
-							Name: heat.ServiceName + "-" + heat.APIComponent,
+							Name: serviceName,
 							Command: []string{
 								"/bin/bash",
 							},
@@ -136,7 +139,7 @@ func Deployment(
 	deployment.Spec.Template.Spec.Affinity = affinity.DistributePods(
 		common.AppSelector,
 		[]string{
-			heat.ServiceName,
+			labels[common.AppSelector],
 		},
 		corev1.LabelHostname,
 	)

--- a/pkg/heatcfnapi/deployment.go
+++ b/pkg/heatcfnapi/deployment.go
@@ -16,6 +16,8 @@ limitations under the License.
 package heatcfnapi
 
 import (
+	"fmt"
+
 	heatv1beta1 "github.com/openstack-k8s-operators/heat-operator/api/v1beta1"
 	heat "github.com/openstack-k8s-operators/heat-operator/pkg/heat"
 	common "github.com/openstack-k8s-operators/lib-common/modules/common"
@@ -89,10 +91,11 @@ func Deployment(
 
 	// Default oslo.service graceful_shutdown_timeout is 60, so align with that
 	terminationGracePeriod := int64(60)
+	serviceName := fmt.Sprintf("%s-%s", heat.ServiceName, heat.CfnAPIComponent)
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      ServiceName,
+			Name:      serviceName,
 			Namespace: instance.Namespace,
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -108,7 +111,7 @@ func Deployment(
 					ServiceAccountName: heat.ServiceAccount,
 					Containers: []corev1.Container{
 						{
-							Name: heat.ServiceName + "-" + heat.CfnAPIComponent,
+							Name: serviceName,
 							Command: []string{
 								"/bin/bash",
 							},
@@ -136,7 +139,7 @@ func Deployment(
 	deployment.Spec.Template.Spec.Affinity = affinity.DistributePods(
 		common.AppSelector,
 		[]string{
-			heat.ServiceName,
+			labels[common.AppSelector],
 		},
 		corev1.LabelHostname,
 	)

--- a/pkg/heatengine/deployment.go
+++ b/pkg/heatengine/deployment.go
@@ -86,10 +86,11 @@ func Deployment(instance *heatv1beta1.HeatEngine, configHash string, labels map[
 
 	// Default oslo.service graceful_shutdown_timeout is 60, so align with that
 	terminationGracePeriod := int64(60)
+	serviceName := fmt.Sprintf("%s-%s", heat.ServiceName, heat.EngineComponent)
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", heat.ServiceName, heat.EngineComponent),
+			Name:      serviceName,
 			Namespace: instance.Namespace,
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -105,7 +106,7 @@ func Deployment(instance *heatv1beta1.HeatEngine, configHash string, labels map[
 					ServiceAccountName: heat.ServiceAccount,
 					Containers: []corev1.Container{
 						{
-							Name: fmt.Sprintf("%s-%s", heat.ServiceName, heat.EngineComponent),
+							Name: serviceName,
 							Command: []string{
 								"/bin/bash",
 							},
@@ -133,7 +134,7 @@ func Deployment(instance *heatv1beta1.HeatEngine, configHash string, labels map[
 	deployment.Spec.Template.Spec.Affinity = affinity.DistributePods(
 		common.AppSelector,
 		[]string{
-			heat.ServiceName,
+			labels[common.AppSelector],
 		},
 		corev1.LabelHostname,
 	)


### PR DESCRIPTION
Currently we use the same name in the affinity policies to distribute pods, but this is wrong and we don't have to allocate pod for different components in different nodes. This fixes the selector and ensures we use the different name for each component.