### PR TITLE
HeatCfnAPI: Fix component selector

### DIFF
--- a/controllers/heatcfnapi_controller.go
+++ b/controllers/heatcfnapi_controller.go
@@ -500,7 +500,7 @@ func (r *HeatCfnAPIReconciler) reconcileNormal(ctx context.Context, instance *he
 
 	serviceLabels := map[string]string{
 		common.AppSelector:     heat.ServiceName,
-		heat.ComponentSelector: heat.APIComponent,
+		heat.ComponentSelector: heat.CfnAPIComponent,
 	}
 
 	// Handle service init


### PR DESCRIPTION
We should use the different selector for Cfn API.