### PR TITLE
Prohibit updating spec.databaseInstance

### DIFF
--- a/tests/functional/heat_controller_test.go
+++ b/tests/functional/heat_controller_test.go
@@ -57,21 +57,21 @@ var _ = Describe("Heat controller", func() {
 		})
 
 		It("should have the Spec fields initialized", func() {
-			Heat := GetHeat(heatName)
-			Expect(Heat.Spec.DatabaseInstance).Should(Equal("openstack"))
-			Expect(Heat.Spec.DatabaseUser).Should(Equal("heat"))
-			Expect(Heat.Spec.RabbitMqClusterName).Should(Equal("rabbitmq"))
-			Expect(Heat.Spec.ServiceUser).Should(Equal("heat"))
+			heat := GetHeat(heatName)
+			Expect(heat.Spec.DatabaseInstance).Should(Equal("openstack"))
+			Expect(heat.Spec.DatabaseUser).Should(Equal("heat"))
+			Expect(heat.Spec.RabbitMqClusterName).Should(Equal("rabbitmq"))
+			Expect(heat.Spec.ServiceUser).Should(Equal("heat"))
 		})
 
 		It("should have the Status fields initialized", func() {
-			Heat := GetHeat(heatName)
-			Expect(Heat.Status.Hash).To(BeEmpty())
-			Expect(Heat.Status.DatabaseHostname).To(Equal(""))
-			Expect(Heat.Status.TransportURLSecret).To(Equal(""))
-			Expect(Heat.Status.HeatAPIReadyCount).To(Equal(int32(0)))
-			Expect(Heat.Status.HeatCfnAPIReadyCount).To(Equal(int32(0)))
-			Expect(Heat.Status.HeatEngineReadyCount).To(Equal(int32(0)))
+			heat := GetHeat(heatName)
+			Expect(heat.Status.Hash).To(BeEmpty())
+			Expect(heat.Status.DatabaseHostname).To(Equal(""))
+			Expect(heat.Status.TransportURLSecret).To(Equal(""))
+			Expect(heat.Status.HeatAPIReadyCount).To(Equal(int32(0)))
+			Expect(heat.Status.HeatCfnAPIReadyCount).To(Equal(int32(0)))
+			Expect(heat.Status.HeatEngineReadyCount).To(Equal(int32(0)))
 		})
 
 		It("should have Unknown Conditions initialized as transporturl not created", func() {

--- a/tests/functional/heat_webhook_test.go
+++ b/tests/functional/heat_webhook_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package functional
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("Heat webhook", func() {
+
+	var heatName types.NamespacedName
+
+	BeforeEach(func() {
+		heatName = types.NamespacedName{
+			Name:      "heat",
+			Namespace: namespace,
+		}
+
+		err := os.Setenv("OPERATOR_TEMPLATES", "../../templates")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	When("databaseInstance is being updated", func() {
+		BeforeEach(func() {
+			DeferCleanup(DeleteInstance, CreateHeat(heatName, GetDefaultHeatSpec()))
+		})
+
+		It("should have created a Heat", func() {
+			Eventually(func(g Gomega) {
+				GetHeat(heatName)
+			}, timeout, interval).Should(Succeed())
+		})
+
+		It("should be blocked by the webhook and fail", func() {
+			heat := GetHeat(heatName)
+			_, err := controllerutil.CreateOrPatch(
+				th.Ctx, th.K8sClient, heat, func() error {
+					heat.Spec.DatabaseInstance = "changed"
+					return nil
+				})
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/tests/functional/suite_test.go
+++ b/tests/functional/suite_test.go
@@ -90,6 +90,13 @@ var _ = BeforeSuite(func() {
 			routev1CRDs,
 		},
 		ErrorIfCRDPathMissing: true,
+		WebhookInstallOptions: envtest.WebhookInstallOptions{
+			Paths: []string{filepath.Join("..", "..", "config", "webhook")},
+			// NOTE(gibi): if localhost is resolved to ::1 (ipv6) then starting
+			// the webhook fails as it try to parse the address as ipv4 and
+			// failing on the colons in ::1
+			LocalServingHost: "127.0.0.1",
+		},
 	}
 
 	// cfg is defined in this file globally.
@@ -120,13 +127,27 @@ var _ = BeforeSuite(func() {
 	th = NewTestHelper(ctx, k8sClient, timeout, interval, logger)
 	Expect(th).NotTo(BeNil())
 
+	// Start the controller-manager if goroutine
+	webhookInstallOptions := &testEnv.WebhookInstallOptions
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,
+		// NOTE(gibi): disable metrics reporting in test to allow
+		// parallel test execution. Otherwise each instance would like to
+		// bind to the same port
+		MetricsBindAddress: "0",
+		Host:               webhookInstallOptions.LocalServingHost,
+		Port:               webhookInstallOptions.LocalServingPort,
+		CertDir:            webhookInstallOptions.LocalServingCertDir,
+		LeaderElection:     false,
 	})
 	Expect(err).ToNot(HaveOccurred())
 
 	kclient, err := kubernetes.NewForConfig(cfg)
 	Expect(err).ToNot(HaveOccurred(), "failed to create kclient")
+
+	err = (&heat.Heat{}).SetupWebhookWithManager(k8sManager)
+	Expect(err).NotTo(HaveOccurred())
+
 	err = (&controllers.HeatReconciler{
 		Client:  k8sManager.GetClient(),
 		Scheme:  k8sManager.GetScheme(),


### PR DESCRIPTION
Updating spec.databaseInstance does not migrate existing data to a new instance and can break resource access unexpectedly. This prohibits such update.