### PR TITLE
Remove spec.databaseHostname from Heat CR

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -33,10 +33,6 @@ type HeatTemplate struct {
 	// TODO: -> implement needs work in mariadb-operator, right now only heat.
 	DatabaseUser string `json:"databaseUser"`
 
-	// +kubebuilder:validation:Optional
-	// DatabaseHostname - Heat Database Hostname
-	DatabaseHostname string `json:"databaseHostname,omitempty"`
-
 	// +kubebuilder:validation:Required
 	// Secret containing OpenStack password information for heat HeatDatabasePassword, HeatPassword
 	// and HeatAuthEncryptionKey

--- a/config/crd/bases/heat.openstack.org_heats.yaml
+++ b/config/crd/bases/heat.openstack.org_heats.yaml
@@ -52,9 +52,6 @@ spec:
                   added to to /etc/<service>/<service>.conf.d directory as custom.conf
                   file.
                 type: string
-              databaseHostname:
-                description: DatabaseHostname - Heat Database Hostname
-                type: string
               databaseInstance:
                 description: MariaDB instance name. Right now required by the maridb-operator
                   to get the credentials from the instance to create the DB. Might


### PR DESCRIPTION
This spec is not used, because the value is determined by underlying mariadb operator. The spec is required in sub CRs.