### PR TITLE
Remove redundant default of PasswordSelectors

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -39,7 +39,6 @@ type HeatTemplate struct {
 	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={database: HeatDatabasePassword, service: HeatPassword, authEncryptionKey: HeatAuthEncryptionKey}
 	// PasswordSelectors - Selectors to identify the DB and ServiceUser password from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
 }

--- a/config/crd/bases/heat.openstack.org_heatapis.yaml
+++ b/config/crd/bases/heat.openstack.org_heatapis.yaml
@@ -89,10 +89,6 @@ spec:
                   the API service
                 type: object
               passwordSelectors:
-                default:
-                  authEncryptionKey: HeatAuthEncryptionKey
-                  database: HeatDatabasePassword
-                  service: HeatPassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
                 properties:

--- a/config/crd/bases/heat.openstack.org_heatcfnapis.yaml
+++ b/config/crd/bases/heat.openstack.org_heatcfnapis.yaml
@@ -89,10 +89,6 @@ spec:
                   the API service
                 type: object
               passwordSelectors:
-                default:
-                  authEncryptionKey: HeatAuthEncryptionKey
-                  database: HeatDatabasePassword
-                  service: HeatPassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
                 properties:

--- a/config/crd/bases/heat.openstack.org_heatengines.yaml
+++ b/config/crd/bases/heat.openstack.org_heatengines.yaml
@@ -89,10 +89,6 @@ spec:
                   the API service
                 type: object
               passwordSelectors:
-                default:
-                  authEncryptionKey: HeatAuthEncryptionKey
-                  database: HeatDatabasePassword
-                  service: HeatPassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
                 properties:

--- a/config/crd/bases/heat.openstack.org_heats.yaml
+++ b/config/crd/bases/heat.openstack.org_heats.yaml
@@ -382,10 +382,6 @@ spec:
                   the Heat services
                 type: object
               passwordSelectors:
-                default:
-                  authEncryptionKey: HeatAuthEncryptionKey
-                  database: HeatDatabasePassword
-                  service: HeatPassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
                 properties:


### PR DESCRIPTION
Currently we define defaults in two layers but this is redundant.