### PR TITLE
Fix common parameter descriptions

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -47,7 +47,7 @@ type HeatTemplate struct {
 // HeatServiceTemplate -
 type HeatServiceTemplate struct {
 	// +kubebuilder:validation:Required
-	// ContainerImage - Heat API Container Image URL
+	// ContainerImage - Container Image URL
 	ContainerImage string `json:"containerImage"`
 
 	// +kubebuilder:validation:Optional
@@ -63,7 +63,7 @@ type HeatServiceTemplate struct {
 	Replicas int32 `json:"replicas"`
 
 	// +kubebuilder:validation:Optional
-	// NodeSelector to target subset of worker nodes for running the API service
+	// NodeSelector to target subset of worker nodes for running the service
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/config/crd/bases/heat.openstack.org_heatapis.yaml
+++ b/config/crd/bases/heat.openstack.org_heatapis.yaml
@@ -45,7 +45,7 @@ spec:
             description: HeatAPISpec defines the desired state of HeatAPI
             properties:
               containerImage:
-                description: ContainerImage - Heat API Container Image URL
+                description: ContainerImage - Container Image URL
                 type: string
               customServiceConfig:
                 default: '# add your customization here'
@@ -86,7 +86,7 @@ spec:
                 additionalProperties:
                   type: string
                 description: NodeSelector to target subset of worker nodes for running
-                  the API service
+                  the service
                 type: object
               passwordSelectors:
                 default:

--- a/config/crd/bases/heat.openstack.org_heatcfnapis.yaml
+++ b/config/crd/bases/heat.openstack.org_heatcfnapis.yaml
@@ -45,7 +45,7 @@ spec:
             description: HeatCfnAPISpec defines the desired state of HeatCfnAPI
             properties:
               containerImage:
-                description: ContainerImage - Heat API Container Image URL
+                description: ContainerImage - Container Image URL
                 type: string
               customServiceConfig:
                 default: '# add your customization here'
@@ -86,7 +86,7 @@ spec:
                 additionalProperties:
                   type: string
                 description: NodeSelector to target subset of worker nodes for running
-                  the API service
+                  the service
                 type: object
               passwordSelectors:
                 default:

--- a/config/crd/bases/heat.openstack.org_heatengines.yaml
+++ b/config/crd/bases/heat.openstack.org_heatengines.yaml
@@ -45,7 +45,7 @@ spec:
             description: HeatEngineSpec defines the desired state of HeatEngine
             properties:
               containerImage:
-                description: ContainerImage - Heat API Container Image URL
+                description: ContainerImage - Container Image URL
                 type: string
               customServiceConfig:
                 default: '# add your customization here'
@@ -86,7 +86,7 @@ spec:
                 additionalProperties:
                   type: string
                 description: NodeSelector to target subset of worker nodes for running
-                  the API service
+                  the service
                 type: object
               passwordSelectors:
                 default:

--- a/config/crd/bases/heat.openstack.org_heats.yaml
+++ b/config/crd/bases/heat.openstack.org_heats.yaml
@@ -86,7 +86,7 @@ spec:
                   Heat deployment
                 properties:
                   containerImage:
-                    description: ContainerImage - Heat API Container Image URL
+                    description: ContainerImage - Container Image URL
                     type: string
                   customServiceConfig:
                     default: '# add your customization here'
@@ -118,7 +118,7 @@ spec:
                     additionalProperties:
                       type: string
                     description: NodeSelector to target subset of worker nodes for
-                      running the API service
+                      running the service
                     type: object
                   replicas:
                     default: 1
@@ -184,7 +184,7 @@ spec:
                   this Heat deployment
                 properties:
                   containerImage:
-                    description: ContainerImage - Heat API Container Image URL
+                    description: ContainerImage - Container Image URL
                     type: string
                   customServiceConfig:
                     default: '# add your customization here'
@@ -216,7 +216,7 @@ spec:
                     additionalProperties:
                       type: string
                     description: NodeSelector to target subset of worker nodes for
-                      running the API service
+                      running the service
                     type: object
                   replicas:
                     default: 1
@@ -282,7 +282,7 @@ spec:
                   this Heat deployment
                 properties:
                   containerImage:
-                    description: ContainerImage - Heat API Container Image URL
+                    description: ContainerImage - Container Image URL
                     type: string
                   customServiceConfig:
                     default: '# add your customization here'
@@ -314,7 +314,7 @@ spec:
                     additionalProperties:
                       type: string
                     description: NodeSelector to target subset of worker nodes for
-                      running the API service
+                      running the service
                     type: object
                   replicas:
                     default: 1


### PR DESCRIPTION
Some parameter descriptions specifically mention API but these are used by not only API but the other services.