### PR TITLE
Remove duplicate secret declaration from tests

### DIFF
--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -144,6 +144,7 @@ func CreateHeatSecret(namespace string, name string) *corev1.Secret {
 		map[string][]byte{
 			"HeatPassword":         []byte("12345678"),
 			"HeatDatabasePassword": []byte("12345678"),
+			"AuthEncryptionKey":    []byte("1234567812345678123456781212345678345678"),
 		},
 	)
 }

--- a/tests/functional/heat_controller_test.go
+++ b/tests/functional/heat_controller_test.go
@@ -142,17 +142,8 @@ var _ = Describe("Heat controller", func() {
 	When("keystoneAPI instance is not available", func() {
 		BeforeEach(func() {
 			DeferCleanup(DeleteInstance, CreateHeat(heatName, GetDefaultHeatSpec()))
-			secret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      SecretName,
-					Namespace: namespace,
-				},
-				Data: map[string][]byte{
-					"HeatPassword": []byte("12345678"),
-				},
-			}
-			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
-			DeferCleanup(k8sClient.Delete, ctx, secret)
+			DeferCleanup(
+				k8sClient.Delete, ctx, CreateHeatSecret(namespace, SecretName))
 			th.SimulateTransportURLReady(heatTransportURLName)
 		})
 		It("should not create a config map", func() {
@@ -165,15 +156,6 @@ var _ = Describe("Heat controller", func() {
 	When("keystoneAPI instance is available", func() {
 		BeforeEach(func() {
 			DeferCleanup(DeleteInstance, CreateHeat(heatName, GetDefaultHeatSpec()))
-			secret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      SecretName,
-					Namespace: namespace,
-				},
-				Data: map[string][]byte{
-					"HeatPassword": []byte("12345678"),
-				},
-			}
 			rmqSecret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "rabbitmq-secret",
@@ -185,8 +167,8 @@ var _ = Describe("Heat controller", func() {
 			}
 			Expect(k8sClient.Create(ctx, rmqSecret)).Should(Succeed())
 			DeferCleanup(k8sClient.Delete, ctx, rmqSecret)
-			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
-			DeferCleanup(k8sClient.Delete, ctx, secret)
+			DeferCleanup(
+				k8sClient.Delete, ctx, CreateHeatSecret(namespace, SecretName))
 			th.SimulateTransportURLReady(heatTransportURLName)
 		})
 


### PR DESCRIPTION
Our base_test.go file has a helper function to create the Heat passwords secret. This change removes duplicate declarations of this secret from the heat_controller_test.go file and replaced them with the helper function.