### PR TITLE
Add capability to set up notification url

### DIFF
--- a/api/bases/heat.openstack.org_heatapis.yaml
+++ b/api/bases/heat.openstack.org_heatapis.yaml
@@ -87,6 +87,10 @@ spec:
                 description: NodeSelector to target subset of worker nodes for running
                   the service
                 type: object
+              notificationURLSecret:
+                description: NotificationURLSecret - Secret containing RabbitMQ transportURL
+                  for notifications
+                type: string
               passwordSelectors:
                 default:
                   authEncryptionKey: HeatAuthEncryptionKey

--- a/api/bases/heat.openstack.org_heatcfnapis.yaml
+++ b/api/bases/heat.openstack.org_heatcfnapis.yaml
@@ -87,6 +87,10 @@ spec:
                 description: NodeSelector to target subset of worker nodes for running
                   the service
                 type: object
+              notificationURLSecret:
+                description: NotificationURLSecret - Secret containing RabbitMQ transportURL
+                  for notifications
+                type: string
               passwordSelectors:
                 default:
                   authEncryptionKey: HeatAuthEncryptionKey

--- a/api/bases/heat.openstack.org_heatengines.yaml
+++ b/api/bases/heat.openstack.org_heatengines.yaml
@@ -87,6 +87,10 @@ spec:
                 description: NodeSelector to target subset of worker nodes for running
                   the service
                 type: object
+              notificationURLSecret:
+                description: NotificationURLSecret - Secret containing RabbitMQ transportURL
+                  for notifications
+                type: string
               passwordSelectors:
                 default:
                   authEncryptionKey: HeatAuthEncryptionKey

--- a/api/bases/heat.openstack.org_heats.yaml
+++ b/api/bases/heat.openstack.org_heats.yaml
@@ -381,6 +381,10 @@ spec:
                 description: NodeSelector to target subset of worker nodes for running
                   the Heat services
                 type: object
+              notificationRabbitMqClusterName:
+                description: Notification RabbitMQ instance name Needed to request
+                  a transportURL that is created and used in Heat for notifcations
+                type: string
               passwordSelectors:
                 default:
                   authEncryptionKey: HeatAuthEncryptionKey
@@ -499,6 +503,10 @@ spec:
                 description: ReadyCount of Heat Engine instance
                 format: int32
                 type: integer
+              notificationURLSecret:
+                description: NotificationURLSecret - Secret containing RabbitMQ transportURL
+                  for notifications
+                type: string
               transportURLSecret:
                 description: TransportURLSecret - Secret containing RabbitMQ transportURL
                 type: string

--- a/api/v1beta1/conditions.go
+++ b/api/v1beta1/conditions.go
@@ -31,6 +31,9 @@ const (
 
 	// HeatStackDomainReadyCondition ...
 	HeatStackDomainReadyCondition condition.Type = "HeatStackDomainReady"
+
+	// HeatRabbitMqNotificationURLReadyCondition Status=True condition which indicates if the RabbitMQ TransportURL is ready
+	HeatRabbitMqNotificationURLReadyCondition condition.Type = "HeatRabbitMqNotificationURLReady"
 )
 
 // Common Messages used by API objects.
@@ -76,4 +79,19 @@ const (
 
 	// HeatStackDomainReadyErrorMessage
 	HeatStackDomainReadyErrorMessage = "HeatStackDomain error occured %s"
+
+	//
+	// HeatRabbitMqNotificationURLReady condition messages
+	//
+	// HeatRabbitMqNotificationURLReadyInitMessage
+	HeatRabbitMqNotificationURLReadyInitMessage = "HeatRabbitMqNotificationURL not started"
+
+	// HeatRabbitMqNotificationURLReadyRunningMessage
+	HeatRabbitMqNotificationURLReadyRunningMessage = "HeatRabbitMqNotificationURL creation in progress"
+
+	// HeatRabbitMqNotificationURLReadyMessage
+	HeatRabbitMqNotificationURLReadyMessage = "HeatRabbitMqNotificationURL successfully created"
+
+	// HeatRabbitMqNotificationURLReadyErrorMessage
+	HeatRabbitMqNotificationURLReadyErrorMessage = "HeatRabbitMqNotificationURL error occured %s"
 )

--- a/api/v1beta1/heat_types.go
+++ b/api/v1beta1/heat_types.go
@@ -97,6 +97,11 @@ type HeatSpec struct {
 	// RabbitMQ instance name
 	// Needed to request a transportURL that is created and used in Heat
 	RabbitMqClusterName string `json:"rabbitMqClusterName"`
+
+	// +kubebuilder:validation:Optional
+	// Notification RabbitMQ instance name
+	// Needed to request a transportURL that is created and used in Heat for notifcations
+	NotificationRabbitMqClusterName string `json:"notificationRabbitMqClusterName,omitempty"`
 }
 
 // HeatStatus defines the observed state of Heat
@@ -112,6 +117,9 @@ type HeatStatus struct {
 
 	// TransportURLSecret - Secret containing RabbitMQ transportURL
 	TransportURLSecret string `json:"transportURLSecret,omitempty"`
+
+	// NotificationURLSecret - Secret containing RabbitMQ transportURL for notifications
+	NotificationURLSecret string `json:"notificationURLSecret,omitempty"`
 
 	// ReadyCount of Heat API instance
 	HeatAPIReadyCount int32 `json:"heatApiReadyCount,omitempty"`

--- a/api/v1beta1/heatapi_types.go
+++ b/api/v1beta1/heatapi_types.go
@@ -43,6 +43,10 @@ type HeatAPISpec struct {
 	// TransportURLSecret - Secret containing RabbitMQ transportURL
 	TransportURLSecret string `json:"transportURLSecret"`
 
+	// +kubebuilder:validation:Optional
+	// NotificationURLSecret - Secret containing RabbitMQ transportURL for notifications
+	NotificationURLSecret string `json:"notificationURLSecret,omitempty"`
+
 	// +kubebuilder:validation:Required
 	// ServiceAccount - service account name used internally to provide Heat services the default SA name
 	ServiceAccount string `json:"serviceAccount"`

--- a/api/v1beta1/heatcfnapi_types.go
+++ b/api/v1beta1/heatcfnapi_types.go
@@ -43,6 +43,10 @@ type HeatCfnAPISpec struct {
 	// TransportURLSecret - Secret containing RabbitMQ transportURL
 	TransportURLSecret string `json:"transportURLSecret"`
 
+	// +kubebuilder:validation:Optional
+	// NotificationURLSecret - Secret containing RabbitMQ transportURL for notifications
+	NotificationURLSecret string `json:"notificationURLSecret,omitempty"`
+
 	// +kubebuilder:validation:Required
 	// ServiceAccount - service account name used internally to provide Heat services the default SA name
 	ServiceAccount string `json:"serviceAccount"`

--- a/api/v1beta1/heatengine_types.go
+++ b/api/v1beta1/heatengine_types.go
@@ -43,6 +43,10 @@ type HeatEngineSpec struct {
 	// TransportURLSecret - Secret containing RabbitMQ transportURL
 	TransportURLSecret string `json:"transportURLSecret"`
 
+	// +kubebuilder:validation:Optional
+	// NotificationURLSecret - Secret containing RabbitMQ transportURL for notifications
+	NotificationURLSecret string `json:"notificationURLSecret,omitempty"`
+
 	// +kubebuilder:validation:Required
 	// ServiceAccount - service account name used internally to provide Heat services the default SA name
 	ServiceAccount string `json:"serviceAccount"`

--- a/config/crd/bases/heat.openstack.org_heatapis.yaml
+++ b/config/crd/bases/heat.openstack.org_heatapis.yaml
@@ -87,6 +87,10 @@ spec:
                 description: NodeSelector to target subset of worker nodes for running
                   the service
                 type: object
+              notificationURLSecret:
+                description: NotificationURLSecret - Secret containing RabbitMQ transportURL
+                  for notifications
+                type: string
               passwordSelectors:
                 default:
                   authEncryptionKey: HeatAuthEncryptionKey

--- a/config/crd/bases/heat.openstack.org_heatcfnapis.yaml
+++ b/config/crd/bases/heat.openstack.org_heatcfnapis.yaml
@@ -87,6 +87,10 @@ spec:
                 description: NodeSelector to target subset of worker nodes for running
                   the service
                 type: object
+              notificationURLSecret:
+                description: NotificationURLSecret - Secret containing RabbitMQ transportURL
+                  for notifications
+                type: string
               passwordSelectors:
                 default:
                   authEncryptionKey: HeatAuthEncryptionKey

--- a/config/crd/bases/heat.openstack.org_heatengines.yaml
+++ b/config/crd/bases/heat.openstack.org_heatengines.yaml
@@ -87,6 +87,10 @@ spec:
                 description: NodeSelector to target subset of worker nodes for running
                   the service
                 type: object
+              notificationURLSecret:
+                description: NotificationURLSecret - Secret containing RabbitMQ transportURL
+                  for notifications
+                type: string
               passwordSelectors:
                 default:
                   authEncryptionKey: HeatAuthEncryptionKey

--- a/config/crd/bases/heat.openstack.org_heats.yaml
+++ b/config/crd/bases/heat.openstack.org_heats.yaml
@@ -381,6 +381,10 @@ spec:
                 description: NodeSelector to target subset of worker nodes for running
                   the Heat services
                 type: object
+              notificationRabbitMqClusterName:
+                description: Notification RabbitMQ instance name Needed to request
+                  a transportURL that is created and used in Heat for notifcations
+                type: string
               passwordSelectors:
                 default:
                   authEncryptionKey: HeatAuthEncryptionKey
@@ -499,6 +503,10 @@ spec:
                 description: ReadyCount of Heat Engine instance
                 format: int32
                 type: integer
+              notificationURLSecret:
+                description: NotificationURLSecret - Secret containing RabbitMQ transportURL
+                  for notifications
+                type: string
               transportURLSecret:
                 description: TransportURLSecret - Secret containing RabbitMQ transportURL
                 type: string

--- a/controllers/heatapi_controller.go
+++ b/controllers/heatapi_controller.go
@@ -293,7 +293,7 @@ func (r *HeatAPIReconciler) reconcileInit(
 		heatapi.ServiceName,
 		serviceLabels,
 		data,
-		time.Second * 5,
+		time.Second*5,
 	)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
@@ -331,7 +331,7 @@ func (r *HeatAPIReconciler) reconcileInit(
 			PasswordSelector:   instance.Spec.PasswordSelectors.Service,
 		}
 
-		ksSvcObj := keystonev1.NewKeystoneService(ksSvcSpec, instance.Namespace, serviceLabels, time.Second * 10)
+		ksSvcObj := keystonev1.NewKeystoneService(ksSvcSpec, instance.Namespace, serviceLabels, time.Second*10)
 		ctrlResult, err = ksSvcObj.CreateOrPatch(ctx, helper)
 		if err != nil || (ctrlResult != ctrl.Result{}) {
 			return ctrlResult, err
@@ -356,7 +356,7 @@ func (r *HeatAPIReconciler) reconcileInit(
 			instance.Namespace,
 			ksEndptSpec,
 			serviceLabels,
-			time.Second * 10)
+			time.Second*10)
 		ctrlResult, err = ksEndpt.CreateOrPatch(ctx, helper)
 		if err != nil || (ctrlResult != ctrl.Result{}) {
 			return ctrlResult, err
@@ -526,7 +526,7 @@ func (r *HeatAPIReconciler) reconcileNormal(ctx context.Context, instance *heatv
 	// Define a new Deployment object
 	depl := deployment.NewDeployment(
 		heatapi.Deployment(instance, inputHash, serviceLabels),
-		time.Second * 5,
+		time.Second*5,
 	)
 
 	ctrlResult, err = depl.CreateOrPatch(ctx, helper)

--- a/controllers/heatcfnapi_controller.go
+++ b/controllers/heatcfnapi_controller.go
@@ -297,7 +297,7 @@ func (r *HeatCfnAPIReconciler) reconcileInit(
 		heatcfnapi.ServiceName,
 		serviceLabels,
 		data,
-		time.Second * 5,
+		time.Second*5,
 	)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
@@ -335,7 +335,7 @@ func (r *HeatCfnAPIReconciler) reconcileInit(
 			PasswordSelector:   instance.Spec.PasswordSelectors.Service,
 		}
 
-		ksSvcObj := keystonev1.NewKeystoneService(ksSvcSpec, instance.Namespace, serviceLabels, time.Second * 10)
+		ksSvcObj := keystonev1.NewKeystoneService(ksSvcSpec, instance.Namespace, serviceLabels, time.Second*10)
 		ctrlResult, err = ksSvcObj.CreateOrPatch(ctx, helper)
 		if err != nil || (ctrlResult != ctrl.Result{}) {
 			return ctrlResult, err
@@ -360,7 +360,7 @@ func (r *HeatCfnAPIReconciler) reconcileInit(
 			instance.Namespace,
 			ksEndptSpec,
 			serviceLabels,
-			time.Second * 10)
+			time.Second*10)
 		ctrlResult, err = ksEndpt.CreateOrPatch(ctx, helper)
 		if err != nil || (ctrlResult != ctrl.Result{}) {
 			return ctrlResult, err
@@ -530,7 +530,7 @@ func (r *HeatCfnAPIReconciler) reconcileNormal(ctx context.Context, instance *he
 	// Define a new Deployment object
 	depl := deployment.NewDeployment(
 		heatcfnapi.Deployment(instance, inputHash, serviceLabels),
-		time.Second * 10,
+		time.Second*10,
 	)
 
 	ctrlResult, err = depl.CreateOrPatch(ctx, helper)

--- a/controllers/heatengine_controller.go
+++ b/controllers/heatengine_controller.go
@@ -369,7 +369,7 @@ func (r *HeatEngineReconciler) reconcileNormal(
 
 	depl := deployment.NewDeployment(
 		heatengine.Deployment(instance, inputHash, serviceLabels),
-		time.Second * 5,
+		time.Second*5,
 	)
 
 	ctrlResult, err = depl.CreateOrPatch(ctx, helper)

--- a/pkg/heat/initcontainer.go
+++ b/pkg/heat/initcontainer.go
@@ -28,6 +28,7 @@ type APIDetails struct {
 	DatabaseUser              string
 	DatabaseName              string
 	TransportURL              string
+	NotificationURL           string
 	OSPSecret                 string
 	DBPasswordSelector        string
 	UserPasswordSelector      string
@@ -109,6 +110,21 @@ func InitContainer(init APIDetails) []corev1.Container {
 			},
 		}
 		envs = append(envs, envTransport)
+	}
+
+	if init.NotificationURL != "" {
+		envNotification := corev1.EnvVar{
+			Name: "NotificationURL",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: init.NotificationURL,
+					},
+					Key: "notification_url",
+				},
+			},
+		}
+		envs = append(envs, envNotification)
 	}
 
 	return []corev1.Container{

--- a/pkg/heatapi/deployment.go
+++ b/pkg/heatapi/deployment.go
@@ -154,6 +154,7 @@ func Deployment(
 		AuthEncryptionKeySelector: instance.Spec.PasswordSelectors.AuthEncryptionKey,
 		VolumeMounts:              getInitVolumeMounts(),
 		TransportURL:              instance.Spec.TransportURLSecret,
+		NotificationURL:           instance.Spec.NotificationURLSecret,
 	}
 	deployment.Spec.Template.Spec.InitContainers = heat.InitContainer(initContainerDetails)
 

--- a/pkg/heatcfnapi/deployment.go
+++ b/pkg/heatcfnapi/deployment.go
@@ -154,6 +154,7 @@ func Deployment(
 		AuthEncryptionKeySelector: instance.Spec.PasswordSelectors.AuthEncryptionKey,
 		VolumeMounts:              getInitVolumeMounts(),
 		TransportURL:              instance.Spec.TransportURLSecret,
+		NotificationURL:           instance.Spec.NotificationURLSecret,
 	}
 	deployment.Spec.Template.Spec.InitContainers = heat.InitContainer(initContainerDetails)
 

--- a/pkg/heatengine/deployment.go
+++ b/pkg/heatengine/deployment.go
@@ -151,6 +151,7 @@ func Deployment(instance *heatv1beta1.HeatEngine, configHash string, labels map[
 		AuthEncryptionKeySelector: instance.Spec.PasswordSelectors.AuthEncryptionKey,
 		VolumeMounts:              getInitVolumeMounts(),
 		TransportURL:              instance.Spec.TransportURLSecret,
+		NotificationURL:           instance.Spec.NotificationURLSecret,
 	}
 	deployment.Spec.Template.Spec.InitContainers = heat.InitContainer(initContainerDetails)
 

--- a/templates/heat/bin/init.sh
+++ b/templates/heat/bin/init.sh
@@ -22,6 +22,7 @@ export DBUSER=${DatabaseUser:-"heat"}
 export DBPASSWORD=${DatabasePassword:?"Please specify a DatabasePassword variable."}
 export PASSWORD=${HeatPassword:?"Please specify a HeatPassword variable."}
 export TRANSPORT_URL=${TransportURL:-""}
+export NOTIFICATION_URL=${NotificationUrl:-""}
 export AUTH_ENCRYPTION_KEY=${AuthEncryptionKey:-""}
 
 export CUSTOMCONF=${CustomConf:-""}
@@ -66,6 +67,9 @@ fi
 # set secrets
 if [ -n "$TRANSPORT_URL" ]; then
     crudini --set ${SVC_CFG_MERGED} DEFAULT transport_url $TRANSPORT_URL
+fi
+if [ -n "$NOTIFICATION_URL" ]; then
+    crudini --set ${SVC_CFG_MERGED} oslo_messaging_notifications transport_url $NOTIFICATION_URL
 fi
 
 # set auth_encryption_key

--- a/tests/functional/suite_test.go
+++ b/tests/functional/suite_test.go
@@ -57,6 +57,8 @@ const (
 	SecretName = "test-osp-secret"
 
 	HeatMessageBusSecretName = "rabbitmq-secret"
+
+	HeatNotificationBusSecretName = "notif-rabbitmq-secret"
 )
 
 func TestAPIs(t *testing.T) {


### PR DESCRIPTION
This introduces the capability to set up RabbitMQ transport url for notifications.

```
[oslo_messaging_notifications]
transport_url=rabbit://<user>:<password>@<host>:<port>/<vhost>
```

Because the notifications should be accessible by external consumers such as ceilometer, this change allows users to use a different RabbitMQ cluster for service transports and notifications.

Note that this change does not modify notification driver. The `[oslo_messaging_notifications] driver` option should be additionally configured by users to enable notifications over RabbitMQ.