### PR TITLE
Add new condition for stack domain creation

### DIFF
--- a/api/v1beta1/conditions.go
+++ b/api/v1beta1/conditions.go
@@ -28,44 +28,43 @@ const (
 
 	// HeatEngineReadyCondition ...
 	HeatEngineReadyCondition condition.Type = "HeatEngineReady"
+
+	// HeatRabbitMqTransportURLReadyCondition Status=True condition which indicates if the RabbitMQ TransportURLUrl is ready
+	HeatRabbitMqTransportURLReadyCondition condition.Type = "HeatRabbitMqTransportURLReady"
+
+	// HeatStackDomainReadyCondition ...
+	HeatStackDomainReadyCondition condition.Type = "HeatStackDomainReady"
 )
 
+// Common Messages used by API objects.
 const (
-	// HeatAPIReadyInitMessage ...
 	//
 	// HeatAPIReady condition messages
 	//
+	// HeatAPIReadyInitMessage ...
 	HeatAPIReadyInitMessage = "HeatAPI not started"
 
 	// HeatAPIReadyErrorMessage ...
 	HeatAPIReadyErrorMessage = "HeatAPI error occured %s"
 
-	// HeatCfnAPIReadyInitMessage ...
 	//
 	// HeatCfnAPIReady condition messages
 	//
+	// HeatCfnAPIReadyInitMessage ...
 	HeatCfnAPIReadyInitMessage = "HeatCfnAPI not started"
 
 	// HeatCfnAPIReadyErrorMessage ...
 	HeatCfnAPIReadyErrorMessage = "HeatCfnAPI error occured %s"
 
-	// HeatEngineReadyInitMessage ...
 	//
 	// HeatEngineReady condition messages
 	//
+	// HeatEngineReadyInitMessage ...
 	HeatEngineReadyInitMessage = "HeatEngine not started"
 
 	// HeatEngineReadyErrorMessage ...
 	HeatEngineReadyErrorMessage = "HeatEngine error occured %s"
-)
 
-const (
-	// HeatRabbitMqTransportURLReadyCondition Status=True condition which indicates if the RabbitMQ TransportURLUrl is ready
-	HeatRabbitMqTransportURLReadyCondition condition.Type = "HeatRabbitMqTransportURLReady"
-)
-
-// Common Messages used by API objects.
-const (
 	//
 	// HeatRabbitMqTransportURLReady condition messages
 	//
@@ -80,4 +79,19 @@ const (
 
 	// HeatRabbitMqTransportURLReadyErrorMessage
 	HeatRabbitMqTransportURLReadyErrorMessage = "HeatRabbitMqTransportURL error occured %s"
+
+	//
+	// HeatStackDomainReady condition messages
+	//
+	// HeatStackDomainReadyInitMessage
+	HeatStackDomainReadyInitMessage = "HeatStackDomain not started"
+
+	// HeatStackDomainReadyRunningMessage
+	HeatStackDomainReadyRunningMessage = "HeatStackDomain creation in progress"
+
+	// HeatStackDomainReadyMessage
+	HeatStackDomainReadyMessage = "HeatStackDomain successfully created"
+
+	// HeatStackDomainReadyErrorMessage
+	HeatStackDomainReadyErrorMessage = "HeatStackDomain error occured %s"
 )

--- a/tests/functional/heat_controller_test.go
+++ b/tests/functional/heat_controller_test.go
@@ -88,48 +88,24 @@ var _ = Describe("Heat controller", func() {
 				condition.InputReadyCondition,
 				corev1.ConditionFalse,
 			)
-			th.ExpectCondition(
-				heatName,
-				ConditionGetterFunc(HeatConditionGetter),
+
+			for _, cond := range []condition.Type{
 				heatv1.HeatRabbitMqTransportURLReadyCondition,
-				corev1.ConditionUnknown,
-			)
-			th.ExpectCondition(
-				heatName,
-				ConditionGetterFunc(HeatConditionGetter),
 				condition.ServiceConfigReadyCondition,
-				corev1.ConditionUnknown,
-			)
-			th.ExpectCondition(
-				heatName,
-				ConditionGetterFunc(HeatConditionGetter),
 				condition.DBReadyCondition,
-				corev1.ConditionUnknown,
-			)
-			th.ExpectCondition(
-				heatName,
-				ConditionGetterFunc(HeatConditionGetter),
 				condition.DBSyncReadyCondition,
-				corev1.ConditionUnknown,
-			)
-			th.ExpectCondition(
-				heatName,
-				ConditionGetterFunc(HeatConditionGetter),
+				heatv1.HeatStackDomainReadyCondition,
 				heatv1.HeatAPIReadyCondition,
-				corev1.ConditionUnknown,
-			)
-			th.ExpectCondition(
-				heatName,
-				ConditionGetterFunc(HeatConditionGetter),
 				heatv1.HeatCfnAPIReadyCondition,
-				corev1.ConditionUnknown,
-			)
-			th.ExpectCondition(
-				heatName,
-				ConditionGetterFunc(HeatConditionGetter),
 				heatv1.HeatEngineReadyCondition,
-				corev1.ConditionUnknown,
-			)
+			} {
+				th.ExpectCondition(
+					heatName,
+					ConditionGetterFunc(HeatConditionGetter),
+					cond,
+					corev1.ConditionUnknown,
+				)
+			}
 		})
 
 		It("should have a finalizer", func() {
@@ -341,6 +317,12 @@ var _ = Describe("Heat controller", func() {
 				condition.DBSyncReadyCondition,
 				corev1.ConditionFalse,
 			)
+			th.ExpectCondition(
+				heatName,
+				ConditionGetterFunc(HeatConditionGetter),
+				heatv1.HeatStackDomainReadyCondition,
+				corev1.ConditionUnknown,
+			)
 		})
 	})
 
@@ -390,6 +372,12 @@ var _ = Describe("Heat controller", func() {
 				ConditionGetterFunc(HeatConditionGetter),
 				condition.DBSyncReadyCondition,
 				corev1.ConditionTrue,
+			)
+			th.ExpectCondition(
+				heatName,
+				ConditionGetterFunc(HeatConditionGetter),
+				heatv1.HeatStackDomainReadyCondition,
+				corev1.ConditionFalse,
 			)
 		})
 	})


### PR DESCRIPTION
This introduces the new HeatStackDomainCondition so that users can observe status of heat stack doamin creation process. Currently failures at that step are not exposed via status and users have to check pod log to find out why the creation is not progressing.