### PR TITLE
Ensure TransportURL Secret exists in sub CRs

### DIFF
--- a/controllers/heatapi_controller.go
+++ b/controllers/heatapi_controller.go
@@ -428,9 +428,32 @@ func (r *HeatAPIReconciler) reconcileNormal(ctx context.Context, instance *heatv
 	// run check OpenStack secret - end
 
 	//
+	// check for required TransportURL secret holding transport URL string
+	//
+	_, hash, err = secret.GetSecret(ctx, helper, instance.Spec.TransportURLSecret, instance.Namespace)
+	if err != nil {
+		if k8s_errors.IsNotFound(err) {
+			instance.Status.Conditions.Set(condition.FalseCondition(
+				condition.InputReadyCondition,
+				condition.RequestedReason,
+				condition.SeverityInfo,
+				condition.InputReadyWaitingMessage))
+			return ctrl.Result{RequeueAfter: time.Second * 10}, fmt.Errorf("Transport secret %s not found", instance.Spec.TransportURLSecret)
+		}
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			condition.InputReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			condition.InputReadyErrorMessage,
+			err.Error()))
+		return ctrl.Result{}, err
+	}
+	configMapVars[instance.Spec.TransportURLSecret] = env.SetValue(hash)
+	// run check TransportURL secret - end
+
+	//
 	// check for required Heat config maps that should have been created by parent Heat CR
 	//
-
 	parentHeatName := heat.GetOwningHeatName(instance)
 
 	configMaps := []string{
@@ -464,7 +487,7 @@ func (r *HeatAPIReconciler) reconcileNormal(ctx context.Context, instance *heatv
 	//
 
 	//
-	// create custom Configmap for this heat volume service
+	// create custom Configmap for this heat-api service
 	//
 	err = r.generateServiceConfigMaps(ctx, helper, instance, &configMapVars)
 	if err != nil {


### PR DESCRIPTION
Missing TransportURL Secret results in failure in the later phase and appears as a deployment failure. To give more clear error, this introduces the early validation of TransportURL Secret.