### PR TITLE
Drop invalid logic to ensure ConfigMap is not created

### DIFF
--- a/tests/functional/heat_controller_test.go
+++ b/tests/functional/heat_controller_test.go
@@ -115,12 +115,6 @@ var _ = Describe("Heat controller", func() {
 				return GetHeat(heatName).Finalizers
 			}, timeout, interval).Should(ContainElement("Heat"))
 		})
-
-		It("should not create a config map", func() {
-			Eventually(func() []corev1.ConfigMap {
-				return th.ListConfigMaps(fmt.Sprintf("%s-%s", heatName.Name, "config-data")).Items
-			}, timeout, interval).Should(BeEmpty())
-		})
 	})
 
 	When("The proper secret is provided", func() {
@@ -155,12 +149,6 @@ var _ = Describe("Heat controller", func() {
 				condition.ServiceConfigReadyCondition,
 				corev1.ConditionUnknown,
 			)
-		})
-
-		It("should not create a config map", func() {
-			Eventually(func() []corev1.ConfigMap {
-				return th.ListConfigMaps(fmt.Sprintf("%s-%s", heatName.Name, "config-data")).Items
-			}, timeout, interval).Should(BeEmpty())
 		})
 	})
 
@@ -206,12 +194,6 @@ var _ = Describe("Heat controller", func() {
 				corev1.ConditionUnknown,
 			)
 		})
-
-		It("should not create a config map", func() {
-			Eventually(func() []corev1.ConfigMap {
-				return th.ListConfigMaps(fmt.Sprintf("%s-%s", heatName.Name, "config-data")).Items
-			}, timeout, interval).Should(BeEmpty())
-		})
 	})
 
 	When("keystoneAPI instance is available", func() {
@@ -254,17 +236,11 @@ var _ = Describe("Heat controller", func() {
 		})
 
 		It("should create a ConfigMap for heat.conf with the heat_domain_admin config option set", func() {
-			configataCM := types.NamespacedName{
+			cm := th.GetConfigMap(types.NamespacedName{
 				Namespace: heatName.Namespace,
 				Name:      fmt.Sprintf("%s-%s", heatName.Name, "config-data"),
-			}
-
-			Eventually(func() corev1.ConfigMap {
-				return *th.GetConfigMap(configataCM)
-			}, timeout, interval).ShouldNot(BeNil())
-
-			//keystone := GetKeystoneAPI(keystoneAPI)
-			Expect(th.GetConfigMap(configataCM).Data["heat.conf"]).Should(
+			})
+			Expect(cm.Data["heat.conf"]).Should(
 				ContainSubstring("stack_domain_admin = heat_stack_domain_admin"))
 		})
 	})


### PR DESCRIPTION
The current logic is invalid, because ListConfigMaps returns a list of ConfigMaps in the given namespace, instead of the ones with the given name.

This drops that invalid logic until we get a proper helper function to ensure a ConfigMap does not exist.