### PR TITLE
Add back namespace name for kuttl config file

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -18,6 +18,7 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
 reportFormat: JSON
 reportName: kuttl-test-heat
+namespace: heat-kuttl-tests
 timeout: 400
 parallel: 1
 suppress:


### PR DESCRIPTION
... following the current usage in other operators (eg. keystone).