### PR TITLE
CSV: Set operator-type: non-standalone

### DIFF
--- a/config/manifests/bases/heat-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/heat-operator.clusterserviceversion.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
+    operators.operatorframework.io/operator-type: non-standalone
   name: heat-operator.v0.0.1
   namespace: openstack
 spec:


### PR DESCRIPTION
This should hide the heat package/bundle in the OpenShift console as we only want the main OpenStack operator to show up there.