### PR TITLE
Fix defaulting of Replicas spec

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -60,7 +60,7 @@ type HeatServiceTemplate struct {
 	// +kubebuilder:validation:Maximum=32
 	// +kubebuilder:validation:Minimum=0
 	// Replicas -
-	Replicas int32 `json:"replicas"`
+	Replicas *int32 `json:"replicas"`
 
 	// +kubebuilder:validation:Optional
 	// NodeSelector to target subset of worker nodes for running the service

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -497,6 +497,11 @@ func (in *HeatServiceDebug) DeepCopy() *HeatServiceDebug {
 func (in *HeatServiceTemplate) DeepCopyInto(out *HeatServiceTemplate) {
 	*out = *in
 	out.Debug = in.Debug
+	if in.Replicas != nil {
+		in, out := &in.Replicas, &out.Replicas
+		*out = new(int32)
+		**out = **in
+	}
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
 		*out = make(map[string]string, len(*in))

--- a/config/samples/heat_v1beta1_heat.yaml
+++ b/config/samples/heat_v1beta1_heat.yaml
@@ -10,19 +10,16 @@ spec:
   debug:
     dbSync: false
   heatAPI:
-    containerImage: "quay.io/podified-antelope-centos9/openstack-heat-api:current-podified"
     customServiceConfig: "# add your customization here"
     debug:
       service: false
     resources: {}
   heatCfnAPI:
-    containerImage: "quay.io/podified-antelope-centos9/openstack-heat-api-cfn:current-podified"
     customServiceConfig: "# add your customization here"
     debug:
       service: false
     resources: {}
   heatEngine:
-    containerImage: "quay.io/podified-antelope-centos9/openstack-heat-engine:current-podified"
     customServiceConfig: "# add your customization here"
     debug:
       service: false

--- a/config/samples/heat_v1beta1_heat.yaml
+++ b/config/samples/heat_v1beta1_heat.yaml
@@ -14,21 +14,18 @@ spec:
     customServiceConfig: "# add your customization here"
     debug:
       service: false
-    replicas: 1
     resources: {}
   heatCfnAPI:
     containerImage: "quay.io/podified-antelope-centos9/openstack-heat-api-cfn:current-podified"
     customServiceConfig: "# add your customization here"
     debug:
       service: false
-    replicas: 1
     resources: {}
   heatEngine:
     containerImage: "quay.io/podified-antelope-centos9/openstack-heat-engine:current-podified"
     customServiceConfig: "# add your customization here"
     debug:
       service: false
-    replicas: 1
     resources: {}
   preserveJobs: false
   secret: osp-secret

--- a/pkg/heatapi/deployment.go
+++ b/pkg/heatapi/deployment.go
@@ -99,7 +99,7 @@ func Deployment(
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,
 			},
-			Replicas: &instance.Spec.Replicas,
+			Replicas: instance.Spec.Replicas,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,

--- a/pkg/heatcfnapi/deployment.go
+++ b/pkg/heatcfnapi/deployment.go
@@ -99,7 +99,7 @@ func Deployment(
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,
 			},
-			Replicas: &instance.Spec.Replicas,
+			Replicas: instance.Spec.Replicas,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,

--- a/pkg/heatengine/deployment.go
+++ b/pkg/heatengine/deployment.go
@@ -96,7 +96,7 @@ func Deployment(instance *heatv1beta1.HeatEngine, configHash string, labels map[
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,
 			},
-			Replicas: &instance.Spec.Replicas,
+			Replicas: instance.Spec.Replicas,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -38,21 +38,15 @@ func GetDefaultHeatSpec() map[string]interface{} {
 }
 
 func GetDefaultHeatAPISpec() map[string]interface{} {
-	return map[string]interface{}{
-		"replicas": 1,
-	}
+	return map[string]interface{}{}
 }
 
 func GetDefaultHeatEngineSpec() map[string]interface{} {
-	return map[string]interface{}{
-		"replicas": 1,
-	}
+	return map[string]interface{}{}
 }
 
 func GetDefaultHeatCFNAPISpec() map[string]interface{} {
-	return map[string]interface{}{
-		"replicas": 1,
-	}
+	return map[string]interface{}{}
 }
 
 func CreateHeat(name types.NamespacedName, spec map[string]interface{}) client.Object {

--- a/tests/functional/heat_controller_test.go
+++ b/tests/functional/heat_controller_test.go
@@ -61,6 +61,9 @@ var _ = Describe("Heat controller", func() {
 			Expect(Heat.Spec.DatabaseUser).Should(Equal("heat"))
 			Expect(Heat.Spec.RabbitMqClusterName).Should(Equal("rabbitmq"))
 			Expect(Heat.Spec.ServiceUser).Should(Equal("heat"))
+			Expect(*(Heat.Spec.HeatAPI.Replicas)).Should(Equal(int32(1)))
+			Expect(*(Heat.Spec.HeatCfnAPI.Replicas)).Should(Equal(int32(1)))
+			Expect(*(Heat.Spec.HeatEngine.Replicas)).Should(Equal(int32(1)))
 		})
 
 		It("should have the Status fields initialized", func() {


### PR DESCRIPTION
Currently the default value are ignored because these specs are set to 0 by webhook. Update the type from `int32` to `*int32` to avoid that behavior and ensure the expected default values are used.