### PR TITLE
Copy rendered CRD files dir to /api/bases in make manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,8 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases && \
+ 	rm -f api/bases/* && cp -a config/crd/bases api/
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/api/bases/heat.openstack.org_heatapis.yaml
+++ b/api/bases/heat.openstack.org_heatapis.yaml
@@ -1,0 +1,251 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  name: heatapis.heat.openstack.org
+spec:
+  group: heat.openstack.org
+  names:
+    kind: HeatAPI
+    listKind: HeatAPIList
+    plural: heatapis
+    singular: heatapi
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Status
+      jsonPath: .status.conditions[0].status
+      name: Status
+      type: string
+    - description: Message
+      jsonPath: .status.conditions[0].message
+      name: Message
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: HeatAPI ...
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HeatAPISpec defines the desired state of HeatAPI
+            properties:
+              containerImage:
+                description: ContainerImage - Container Image URL
+                type: string
+              customServiceConfig:
+                default: '# add your customization here'
+                description: CustomServiceConfig - customize the service config using
+                  this parameter to change service defaults, or overwrite rendered
+                  information using raw OpenStack config format. The content gets
+                  added to to /etc/<service>/<service>.conf.d directory as custom.conf
+                  file.
+                type: string
+              databaseHostname:
+                description: DatabaseHostname - Heat Database Hostname
+                type: string
+              databaseUser:
+                default: heat
+                description: 'DatabaseUser - optional username used for heat DB, defaults
+                  to heat. TODO: -> implement needs work in mariadb-operator, right
+                  now only heat.'
+                type: string
+              debug:
+                description: Debug - enable debug for different deploy stages. If
+                  an init container is used, it runs and the actual action pod gets
+                  started with sleep infinity
+                properties:
+                  service:
+                    default: false
+                    description: Service enable debug
+                    type: boolean
+                type: object
+              defaultConfigOverwrite:
+                additionalProperties:
+                  type: string
+                description: 'ConfigOverwrite - interface to overwrite default config
+                  files like e.g. policy.json. But can also be used to add additional
+                  files. Those get added to the service config dir in /etc/<service>
+                  . TODO: -> implement'
+                type: object
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector to target subset of worker nodes for running
+                  the service
+                type: object
+              passwordSelectors:
+                default:
+                  authEncryptionKey: HeatAuthEncryptionKey
+                  database: HeatDatabasePassword
+                  service: HeatPassword
+                description: PasswordSelectors - Selectors to identify the DB and
+                  ServiceUser password from the Secret
+                properties:
+                  authEncryptionKey:
+                    default: HeatAuthEncryptionKey
+                    description: AuthEncryptionKey - Selector to get the heat auth
+                      encryption key from the Secret
+                    type: string
+                  database:
+                    default: HeatDatabasePassword
+                    description: 'Database - Selector to get the heat Database user
+                      password from the Secret TODO: not used, need change in mariadb-operator'
+                    type: string
+                  service:
+                    default: HeatPassword
+                    description: Service - Selector to get the heat service password
+                      from the Secret
+                    type: string
+                type: object
+              replicas:
+                default: 1
+                description: Replicas -
+                format: int32
+                maximum: 32
+                minimum: 0
+                type: integer
+              resources:
+                description: Resources - Compute Resources required by this service
+                  (Limits/Requests). https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                properties:
+                  claims:
+                    description: "Claims lists the names of resources, defined in
+                      spec.resourceClaims, that are used by this container. \n This
+                      is an alpha field and requires enabling the DynamicResourceAllocation
+                      feature gate. \n This field is immutable. It can only be set
+                      for containers."
+                    items:
+                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                      properties:
+                        name:
+                          description: Name must match the name of one entry in pod.spec.resourceClaims
+                            of the Pod where this field is used. It makes that resource
+                            available inside a container.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                type: object
+              secret:
+                description: Secret containing OpenStack password information for
+                  heat HeatDatabasePassword, HeatPassword and HeatAuthEncryptionKey
+                type: string
+              serviceAccount:
+                description: ServiceAccount - service account name used internally
+                  to provide Heat services the default SA name
+                type: string
+              serviceUser:
+                default: heat
+                description: ServiceUser - optional username used for this service
+                  to register in heat
+                type: string
+              transportURLSecret:
+                description: TransportURLSecret - Secret containing RabbitMQ transportURL
+                type: string
+            required:
+            - containerImage
+            - secret
+            - serviceAccount
+            type: object
+          status:
+            description: HeatAPIStatus defines the observed state of HeatAPI
+            properties:
+              conditions:
+                description: Conditions
+                items:
+                  description: Condition defines an observation of a API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase.
+                      type: string
+                    severity:
+                      description: Severity provides a classification of Reason code,
+                        so the current situation is immediately understandable and
+                        could act accordingly. It is meant for situations where Status=False
+                        and it should be indicated if it is just informational, warning
+                        (next reconciliation might fix it) or an error (e.g. DB create
+                        issue and no actions to automatically resolve the issue can/should
+                        be done). For conditions where Status=Unknown or Status=True
+                        the Severity should be SeverityNone.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              hash:
+                additionalProperties:
+                  type: string
+                description: Map of hashes to track e.g. job status
+                type: object
+              readyCount:
+                description: ReadyCount of HeatAPI instances
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/api/bases/heat.openstack.org_heatcfnapis.yaml
+++ b/api/bases/heat.openstack.org_heatcfnapis.yaml
@@ -1,0 +1,251 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  name: heatcfnapis.heat.openstack.org
+spec:
+  group: heat.openstack.org
+  names:
+    kind: HeatCfnAPI
+    listKind: HeatCfnAPIList
+    plural: heatcfnapis
+    singular: heatcfnapi
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Status
+      jsonPath: .status.conditions[0].status
+      name: Status
+      type: string
+    - description: Message
+      jsonPath: .status.conditions[0].message
+      name: Message
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: HeatCfnAPI ...
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HeatCfnAPISpec defines the desired state of HeatCfnAPI
+            properties:
+              containerImage:
+                description: ContainerImage - Container Image URL
+                type: string
+              customServiceConfig:
+                default: '# add your customization here'
+                description: CustomServiceConfig - customize the service config using
+                  this parameter to change service defaults, or overwrite rendered
+                  information using raw OpenStack config format. The content gets
+                  added to to /etc/<service>/<service>.conf.d directory as custom.conf
+                  file.
+                type: string
+              databaseHostname:
+                description: DatabaseHostname - Heat Database Hostname
+                type: string
+              databaseUser:
+                default: heat
+                description: 'DatabaseUser - optional username used for heat DB, defaults
+                  to heat. TODO: -> implement needs work in mariadb-operator, right
+                  now only heat.'
+                type: string
+              debug:
+                description: Debug - enable debug for different deploy stages. If
+                  an init container is used, it runs and the actual action pod gets
+                  started with sleep infinity
+                properties:
+                  service:
+                    default: false
+                    description: Service enable debug
+                    type: boolean
+                type: object
+              defaultConfigOverwrite:
+                additionalProperties:
+                  type: string
+                description: 'ConfigOverwrite - interface to overwrite default config
+                  files like e.g. policy.json. But can also be used to add additional
+                  files. Those get added to the service config dir in /etc/<service>
+                  . TODO: -> implement'
+                type: object
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector to target subset of worker nodes for running
+                  the service
+                type: object
+              passwordSelectors:
+                default:
+                  authEncryptionKey: HeatAuthEncryptionKey
+                  database: HeatDatabasePassword
+                  service: HeatPassword
+                description: PasswordSelectors - Selectors to identify the DB and
+                  ServiceUser password from the Secret
+                properties:
+                  authEncryptionKey:
+                    default: HeatAuthEncryptionKey
+                    description: AuthEncryptionKey - Selector to get the heat auth
+                      encryption key from the Secret
+                    type: string
+                  database:
+                    default: HeatDatabasePassword
+                    description: 'Database - Selector to get the heat Database user
+                      password from the Secret TODO: not used, need change in mariadb-operator'
+                    type: string
+                  service:
+                    default: HeatPassword
+                    description: Service - Selector to get the heat service password
+                      from the Secret
+                    type: string
+                type: object
+              replicas:
+                default: 1
+                description: Replicas -
+                format: int32
+                maximum: 32
+                minimum: 0
+                type: integer
+              resources:
+                description: Resources - Compute Resources required by this service
+                  (Limits/Requests). https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                properties:
+                  claims:
+                    description: "Claims lists the names of resources, defined in
+                      spec.resourceClaims, that are used by this container. \n This
+                      is an alpha field and requires enabling the DynamicResourceAllocation
+                      feature gate. \n This field is immutable. It can only be set
+                      for containers."
+                    items:
+                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                      properties:
+                        name:
+                          description: Name must match the name of one entry in pod.spec.resourceClaims
+                            of the Pod where this field is used. It makes that resource
+                            available inside a container.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                type: object
+              secret:
+                description: Secret containing OpenStack password information for
+                  heat HeatDatabasePassword, HeatPassword and HeatAuthEncryptionKey
+                type: string
+              serviceAccount:
+                description: ServiceAccount - service account name used internally
+                  to provide Heat services the default SA name
+                type: string
+              serviceUser:
+                default: heat
+                description: ServiceUser - optional username used for this service
+                  to register in heat
+                type: string
+              transportURLSecret:
+                description: TransportURLSecret - Secret containing RabbitMQ transportURL
+                type: string
+            required:
+            - containerImage
+            - secret
+            - serviceAccount
+            type: object
+          status:
+            description: HeatCfnAPIStatus defines the observed state of HeatCfnAPI
+            properties:
+              conditions:
+                description: Conditions
+                items:
+                  description: Condition defines an observation of a API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase.
+                      type: string
+                    severity:
+                      description: Severity provides a classification of Reason code,
+                        so the current situation is immediately understandable and
+                        could act accordingly. It is meant for situations where Status=False
+                        and it should be indicated if it is just informational, warning
+                        (next reconciliation might fix it) or an error (e.g. DB create
+                        issue and no actions to automatically resolve the issue can/should
+                        be done). For conditions where Status=Unknown or Status=True
+                        the Severity should be SeverityNone.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              hash:
+                additionalProperties:
+                  type: string
+                description: Map of hashes to track e.g. job status
+                type: object
+              readyCount:
+                description: ReadyCount of HeatCfnAPI instances
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/api/bases/heat.openstack.org_heatengines.yaml
+++ b/api/bases/heat.openstack.org_heatengines.yaml
@@ -1,0 +1,251 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  name: heatengines.heat.openstack.org
+spec:
+  group: heat.openstack.org
+  names:
+    kind: HeatEngine
+    listKind: HeatEngineList
+    plural: heatengines
+    singular: heatengine
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Status
+      jsonPath: .status.conditions[0].status
+      name: Status
+      type: string
+    - description: Message
+      jsonPath: .status.conditions[0].message
+      name: Message
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: HeatEngine defined.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HeatEngineSpec defines the desired state of HeatEngine
+            properties:
+              containerImage:
+                description: ContainerImage - Container Image URL
+                type: string
+              customServiceConfig:
+                default: '# add your customization here'
+                description: CustomServiceConfig - customize the service config using
+                  this parameter to change service defaults, or overwrite rendered
+                  information using raw OpenStack config format. The content gets
+                  added to to /etc/<service>/<service>.conf.d directory as custom.conf
+                  file.
+                type: string
+              databaseHostname:
+                description: DatabaseHostname - Heat Database Hostname
+                type: string
+              databaseUser:
+                default: heat
+                description: 'DatabaseUser - optional username used for heat DB, defaults
+                  to heat. TODO: -> implement needs work in mariadb-operator, right
+                  now only heat.'
+                type: string
+              debug:
+                description: Debug - enable debug for different deploy stages. If
+                  an init container is used, it runs and the actual action pod gets
+                  started with sleep infinity
+                properties:
+                  service:
+                    default: false
+                    description: Service enable debug
+                    type: boolean
+                type: object
+              defaultConfigOverwrite:
+                additionalProperties:
+                  type: string
+                description: 'ConfigOverwrite - interface to overwrite default config
+                  files like e.g. policy.json. But can also be used to add additional
+                  files. Those get added to the service config dir in /etc/<service>
+                  . TODO: -> implement'
+                type: object
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector to target subset of worker nodes for running
+                  the service
+                type: object
+              passwordSelectors:
+                default:
+                  authEncryptionKey: HeatAuthEncryptionKey
+                  database: HeatDatabasePassword
+                  service: HeatPassword
+                description: PasswordSelectors - Selectors to identify the DB and
+                  ServiceUser password from the Secret
+                properties:
+                  authEncryptionKey:
+                    default: HeatAuthEncryptionKey
+                    description: AuthEncryptionKey - Selector to get the heat auth
+                      encryption key from the Secret
+                    type: string
+                  database:
+                    default: HeatDatabasePassword
+                    description: 'Database - Selector to get the heat Database user
+                      password from the Secret TODO: not used, need change in mariadb-operator'
+                    type: string
+                  service:
+                    default: HeatPassword
+                    description: Service - Selector to get the heat service password
+                      from the Secret
+                    type: string
+                type: object
+              replicas:
+                default: 1
+                description: Replicas -
+                format: int32
+                maximum: 32
+                minimum: 0
+                type: integer
+              resources:
+                description: Resources - Compute Resources required by this service
+                  (Limits/Requests). https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                properties:
+                  claims:
+                    description: "Claims lists the names of resources, defined in
+                      spec.resourceClaims, that are used by this container. \n This
+                      is an alpha field and requires enabling the DynamicResourceAllocation
+                      feature gate. \n This field is immutable. It can only be set
+                      for containers."
+                    items:
+                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                      properties:
+                        name:
+                          description: Name must match the name of one entry in pod.spec.resourceClaims
+                            of the Pod where this field is used. It makes that resource
+                            available inside a container.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                type: object
+              secret:
+                description: Secret containing OpenStack password information for
+                  heat HeatDatabasePassword, HeatPassword and HeatAuthEncryptionKey
+                type: string
+              serviceAccount:
+                description: ServiceAccount - service account name used internally
+                  to provide Heat services the default SA name
+                type: string
+              serviceUser:
+                default: heat
+                description: ServiceUser - optional username used for this service
+                  to register in heat
+                type: string
+              transportURLSecret:
+                description: TransportURLSecret - Secret containing RabbitMQ transportURL
+                type: string
+            required:
+            - containerImage
+            - secret
+            - serviceAccount
+            type: object
+          status:
+            description: HeatEngineStatus defines the observed state of HeatEngine
+            properties:
+              conditions:
+                description: Conditions
+                items:
+                  description: Condition defines an observation of a API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase.
+                      type: string
+                    severity:
+                      description: Severity provides a classification of Reason code,
+                        so the current situation is immediately understandable and
+                        could act accordingly. It is meant for situations where Status=False
+                        and it should be indicated if it is just informational, warning
+                        (next reconciliation might fix it) or an error (e.g. DB create
+                        issue and no actions to automatically resolve the issue can/should
+                        be done). For conditions where Status=Unknown or Status=True
+                        the Severity should be SeverityNone.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              hash:
+                additionalProperties:
+                  type: string
+                description: Map of hashes to track e.g. job status
+                type: object
+              readyCount:
+                description: ReadyCount of HeatEngine instances
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/api/bases/heat.openstack.org_heats.yaml
+++ b/api/bases/heat.openstack.org_heats.yaml
@@ -1,0 +1,509 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  name: heats.heat.openstack.org
+spec:
+  group: heat.openstack.org
+  names:
+    kind: Heat
+    listKind: HeatList
+    plural: heats
+    singular: heat
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Status
+      jsonPath: .status.conditions[0].status
+      name: Status
+      type: string
+    - description: Message
+      jsonPath: .status.conditions[0].message
+      name: Message
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Heat is the Schema for the heats API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HeatSpec defines the desired state of Heat
+            properties:
+              customServiceConfig:
+                default: '# add your customization here'
+                description: CustomServiceConfig - customize the service config using
+                  this parameter to change service defaults, or overwrite rendered
+                  information using raw OpenStack config format. The content gets
+                  added to to /etc/<service>/<service>.conf.d directory as custom.conf
+                  file.
+                type: string
+              databaseInstance:
+                description: MariaDB instance name. Right now required by the maridb-operator
+                  to get the credentials from the instance to create the DB. Might
+                  not be required in future.
+                type: string
+              databaseUser:
+                default: heat
+                description: 'DatabaseUser - optional username used for heat DB, defaults
+                  to heat. TODO: -> implement needs work in mariadb-operator, right
+                  now only heat.'
+                type: string
+              debug:
+                description: Debug - enable debug for different deploy stages. If
+                  an init container is used, it runs and the actual action pod gets
+                  started with sleep infinity
+                properties:
+                  dbSync:
+                    default: false
+                    description: DBSync enable debug
+                    type: boolean
+                type: object
+              defaultConfigOverwrite:
+                additionalProperties:
+                  type: string
+                description: 'ConfigOverwrite - interface to overwrite default config
+                  files like e.g. policy.json. But can also be used to add additional
+                  files. Those get added to the service config dir in /etc/<service>
+                  . TODO: -> implement'
+                type: object
+              heatAPI:
+                description: HeatAPI - Spec definition for the API service of this
+                  Heat deployment
+                properties:
+                  containerImage:
+                    description: ContainerImage - Container Image URL
+                    type: string
+                  customServiceConfig:
+                    default: '# add your customization here'
+                    description: CustomServiceConfig - customize the service config
+                      using this parameter to change service defaults, or overwrite
+                      rendered information using raw OpenStack config format. The
+                      content gets added to to /etc/<service>/<service>.conf.d directory
+                      as custom.conf file.
+                    type: string
+                  debug:
+                    description: Debug - enable debug for different deploy stages.
+                      If an init container is used, it runs and the actual action
+                      pod gets started with sleep infinity
+                    properties:
+                      service:
+                        default: false
+                        description: Service enable debug
+                        type: boolean
+                    type: object
+                  defaultConfigOverwrite:
+                    additionalProperties:
+                      type: string
+                    description: 'ConfigOverwrite - interface to overwrite default
+                      config files like e.g. policy.json. But can also be used to
+                      add additional files. Those get added to the service config
+                      dir in /etc/<service> . TODO: -> implement'
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: NodeSelector to target subset of worker nodes for
+                      running the service
+                    type: object
+                  replicas:
+                    default: 1
+                    description: Replicas -
+                    format: int32
+                    maximum: 32
+                    minimum: 0
+                    type: integer
+                  resources:
+                    description: Resources - Compute Resources required by this service
+                      (Limits/Requests). https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    properties:
+                      claims:
+                        description: "Claims lists the names of resources, defined
+                          in spec.resourceClaims, that are used by this container.
+                          \n This is an alpha field and requires enabling the DynamicResourceAllocation
+                          feature gate. \n This field is immutable. It can only be
+                          set for containers."
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: Name must match the name of one entry in
+                                pod.spec.resourceClaims of the Pod where this field
+                                is used. It makes that resource available inside a
+                                container.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                required:
+                - containerImage
+                type: object
+              heatCfnAPI:
+                description: HeatCfnAPI - Spec definition for the CfnAPI service of
+                  this Heat deployment
+                properties:
+                  containerImage:
+                    description: ContainerImage - Container Image URL
+                    type: string
+                  customServiceConfig:
+                    default: '# add your customization here'
+                    description: CustomServiceConfig - customize the service config
+                      using this parameter to change service defaults, or overwrite
+                      rendered information using raw OpenStack config format. The
+                      content gets added to to /etc/<service>/<service>.conf.d directory
+                      as custom.conf file.
+                    type: string
+                  debug:
+                    description: Debug - enable debug for different deploy stages.
+                      If an init container is used, it runs and the actual action
+                      pod gets started with sleep infinity
+                    properties:
+                      service:
+                        default: false
+                        description: Service enable debug
+                        type: boolean
+                    type: object
+                  defaultConfigOverwrite:
+                    additionalProperties:
+                      type: string
+                    description: 'ConfigOverwrite - interface to overwrite default
+                      config files like e.g. policy.json. But can also be used to
+                      add additional files. Those get added to the service config
+                      dir in /etc/<service> . TODO: -> implement'
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: NodeSelector to target subset of worker nodes for
+                      running the service
+                    type: object
+                  replicas:
+                    default: 1
+                    description: Replicas -
+                    format: int32
+                    maximum: 32
+                    minimum: 0
+                    type: integer
+                  resources:
+                    description: Resources - Compute Resources required by this service
+                      (Limits/Requests). https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    properties:
+                      claims:
+                        description: "Claims lists the names of resources, defined
+                          in spec.resourceClaims, that are used by this container.
+                          \n This is an alpha field and requires enabling the DynamicResourceAllocation
+                          feature gate. \n This field is immutable. It can only be
+                          set for containers."
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: Name must match the name of one entry in
+                                pod.spec.resourceClaims of the Pod where this field
+                                is used. It makes that resource available inside a
+                                container.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                required:
+                - containerImage
+                type: object
+              heatEngine:
+                description: HeatEngine - Spec definition for the Engine service of
+                  this Heat deployment
+                properties:
+                  containerImage:
+                    description: ContainerImage - Container Image URL
+                    type: string
+                  customServiceConfig:
+                    default: '# add your customization here'
+                    description: CustomServiceConfig - customize the service config
+                      using this parameter to change service defaults, or overwrite
+                      rendered information using raw OpenStack config format. The
+                      content gets added to to /etc/<service>/<service>.conf.d directory
+                      as custom.conf file.
+                    type: string
+                  debug:
+                    description: Debug - enable debug for different deploy stages.
+                      If an init container is used, it runs and the actual action
+                      pod gets started with sleep infinity
+                    properties:
+                      service:
+                        default: false
+                        description: Service enable debug
+                        type: boolean
+                    type: object
+                  defaultConfigOverwrite:
+                    additionalProperties:
+                      type: string
+                    description: 'ConfigOverwrite - interface to overwrite default
+                      config files like e.g. policy.json. But can also be used to
+                      add additional files. Those get added to the service config
+                      dir in /etc/<service> . TODO: -> implement'
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: NodeSelector to target subset of worker nodes for
+                      running the service
+                    type: object
+                  replicas:
+                    default: 1
+                    description: Replicas -
+                    format: int32
+                    maximum: 32
+                    minimum: 0
+                    type: integer
+                  resources:
+                    description: Resources - Compute Resources required by this service
+                      (Limits/Requests). https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    properties:
+                      claims:
+                        description: "Claims lists the names of resources, defined
+                          in spec.resourceClaims, that are used by this container.
+                          \n This is an alpha field and requires enabling the DynamicResourceAllocation
+                          feature gate. \n This field is immutable. It can only be
+                          set for containers."
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: Name must match the name of one entry in
+                                pod.spec.resourceClaims of the Pod where this field
+                                is used. It makes that resource available inside a
+                                container.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                required:
+                - containerImage
+                type: object
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector to target subset of worker nodes for running
+                  the Heat services
+                type: object
+              passwordSelectors:
+                default:
+                  authEncryptionKey: HeatAuthEncryptionKey
+                  database: HeatDatabasePassword
+                  service: HeatPassword
+                description: PasswordSelectors - Selectors to identify the DB and
+                  ServiceUser password from the Secret
+                properties:
+                  authEncryptionKey:
+                    default: HeatAuthEncryptionKey
+                    description: AuthEncryptionKey - Selector to get the heat auth
+                      encryption key from the Secret
+                    type: string
+                  database:
+                    default: HeatDatabasePassword
+                    description: 'Database - Selector to get the heat Database user
+                      password from the Secret TODO: not used, need change in mariadb-operator'
+                    type: string
+                  service:
+                    default: HeatPassword
+                    description: Service - Selector to get the heat service password
+                      from the Secret
+                    type: string
+                type: object
+              preserveJobs:
+                default: false
+                description: PreserveJobs - do not delete jobs after they finished
+                  e.g. to check logs
+                type: boolean
+              rabbitMqClusterName:
+                default: rabbitmq
+                description: RabbitMQ instance name Needed to request a transportURL
+                  that is created and used in Heat
+                type: string
+              secret:
+                description: Secret containing OpenStack password information for
+                  heat HeatDatabasePassword, HeatPassword and HeatAuthEncryptionKey
+                type: string
+              serviceUser:
+                default: heat
+                description: ServiceUser - optional username used for this service
+                  to register in heat
+                type: string
+            required:
+            - databaseInstance
+            - heatAPI
+            - heatCfnAPI
+            - heatEngine
+            - rabbitMqClusterName
+            - secret
+            type: object
+          status:
+            description: HeatStatus defines the observed state of Heat
+            properties:
+              conditions:
+                description: Conditions
+                items:
+                  description: Condition defines an observation of a API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase.
+                      type: string
+                    severity:
+                      description: Severity provides a classification of Reason code,
+                        so the current situation is immediately understandable and
+                        could act accordingly. It is meant for situations where Status=False
+                        and it should be indicated if it is just informational, warning
+                        (next reconciliation might fix it) or an error (e.g. DB create
+                        issue and no actions to automatically resolve the issue can/should
+                        be done). For conditions where Status=Unknown or Status=True
+                        the Severity should be SeverityNone.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              databaseHostname:
+                description: Heat Database Hostname
+                type: string
+              hash:
+                additionalProperties:
+                  type: string
+                description: Map of hashes to track e.g. job status
+                type: object
+              heatApiReadyCount:
+                description: ReadyCount of Heat API instance
+                format: int32
+                type: integer
+              heatCfnApiReadyCount:
+                description: ReadyCount of Heat CfnAPI instance
+                format: int32
+                type: integer
+              heatEngineReadyCount:
+                description: ReadyCount of Heat Engine instance
+                format: int32
+                type: integer
+              transportURLSecret:
+                description: TransportURLSecret - Secret containing RabbitMQ transportURL
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
With the new api sub module, consumer operators just have to import the api submodule. For envtest it is required to install CRD for e.g. keystone-operator and mariadb-operator to be able to use it.

Moving the directory config/crd/bases which holds the generated files in to the api module that they are available with the module and link the dir in the original place does not work as kustomize autodetect fails on symlinked directories [1].

This updates the `generate` Makefile target to copy config/crd/bases to /api on successful generation run.