### PR TITLE
Update Heat kuttl sample to test webhook

### DIFF
--- a/tests/kuttl/common/assert-sample-deployment.yaml
+++ b/tests/kuttl/common/assert-sample-deployment.yaml
@@ -20,21 +20,18 @@ spec:
   debug:
     dbSync: false
   heatAPI:
-    containerImage: "quay.io/podified-antelope-centos9/openstack-heat-api:current-podified"
     customServiceConfig: "# add your customization here"
     debug:
       service: false
     replicas: 1
     resources: {}
   heatCfnAPI:
-    containerImage: "quay.io/podified-antelope-centos9/openstack-heat-api-cfn:current-podified"
     customServiceConfig: "# add your customization here"
     debug:
       service: false
     replicas: 1
     resources: {}
   heatEngine:
-    containerImage: "quay.io/podified-antelope-centos9/openstack-heat-engine:current-podified"
     customServiceConfig: "# add your customization here"
     debug:
       service: false


### PR DESCRIPTION
By removing parameters that will receive their defaults from the webhook, we can validate functionality in our kuttl tests. This change updates the template being used to create the Heat deployment, based on the current config/sample. It additionally removes the `containerImage` parameter to assert whether the value is applied via the webhook.