### PR TITLE
Fix override of CustomServiceConfig

### DIFF
--- a/api/bases/heat.openstack.org_heatapis.yaml
+++ b/api/bases/heat.openstack.org_heatapis.yaml
@@ -48,7 +48,6 @@ spec:
                 description: ContainerImage - Container Image URL
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets

--- a/api/bases/heat.openstack.org_heatcfnapis.yaml
+++ b/api/bases/heat.openstack.org_heatcfnapis.yaml
@@ -48,7 +48,6 @@ spec:
                 description: ContainerImage - Container Image URL
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets

--- a/api/bases/heat.openstack.org_heatengines.yaml
+++ b/api/bases/heat.openstack.org_heatengines.yaml
@@ -48,7 +48,6 @@ spec:
                 description: ContainerImage - Container Image URL
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets

--- a/api/bases/heat.openstack.org_heats.yaml
+++ b/api/bases/heat.openstack.org_heats.yaml
@@ -89,7 +89,6 @@ spec:
                     description: ContainerImage - Container Image URL
                     type: string
                   customServiceConfig:
-                    default: '# add your customization here'
                     description: CustomServiceConfig - customize the service config
                       using this parameter to change service defaults, or overwrite
                       rendered information using raw OpenStack config format. The
@@ -187,7 +186,6 @@ spec:
                     description: ContainerImage - Container Image URL
                     type: string
                   customServiceConfig:
-                    default: '# add your customization here'
                     description: CustomServiceConfig - customize the service config
                       using this parameter to change service defaults, or overwrite
                       rendered information using raw OpenStack config format. The
@@ -285,7 +283,6 @@ spec:
                     description: ContainerImage - Container Image URL
                     type: string
                   customServiceConfig:
-                    default: '# add your customization here'
                     description: CustomServiceConfig - customize the service config
                       using this parameter to change service defaults, or overwrite
                       rendered information using raw OpenStack config format. The

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -72,11 +72,10 @@ type HeatServiceTemplate struct {
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="# add your customization here"
 	// CustomServiceConfig - customize the service config using this parameter to change service defaults,
 	// or overwrite rendered information using raw OpenStack config format. The content gets added to
 	// to /etc/<service>/<service>.conf.d directory as custom.conf file.
-	CustomServiceConfig string `json:"customServiceConfig"`
+	CustomServiceConfig string `json:"customServiceConfig,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// ConfigOverwrite - interface to overwrite default config files like e.g. policy.json.

--- a/config/crd/bases/heat.openstack.org_heatapis.yaml
+++ b/config/crd/bases/heat.openstack.org_heatapis.yaml
@@ -48,7 +48,6 @@ spec:
                 description: ContainerImage - Container Image URL
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets

--- a/config/crd/bases/heat.openstack.org_heatcfnapis.yaml
+++ b/config/crd/bases/heat.openstack.org_heatcfnapis.yaml
@@ -48,7 +48,6 @@ spec:
                 description: ContainerImage - Container Image URL
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets

--- a/config/crd/bases/heat.openstack.org_heatengines.yaml
+++ b/config/crd/bases/heat.openstack.org_heatengines.yaml
@@ -48,7 +48,6 @@ spec:
                 description: ContainerImage - Container Image URL
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets

--- a/config/crd/bases/heat.openstack.org_heats.yaml
+++ b/config/crd/bases/heat.openstack.org_heats.yaml
@@ -89,7 +89,6 @@ spec:
                     description: ContainerImage - Container Image URL
                     type: string
                   customServiceConfig:
-                    default: '# add your customization here'
                     description: CustomServiceConfig - customize the service config
                       using this parameter to change service defaults, or overwrite
                       rendered information using raw OpenStack config format. The
@@ -187,7 +186,6 @@ spec:
                     description: ContainerImage - Container Image URL
                     type: string
                   customServiceConfig:
-                    default: '# add your customization here'
                     description: CustomServiceConfig - customize the service config
                       using this parameter to change service defaults, or overwrite
                       rendered information using raw OpenStack config format. The
@@ -285,7 +283,6 @@ spec:
                     description: ContainerImage - Container Image URL
                     type: string
                   customServiceConfig:
-                    default: '# add your customization here'
                     description: CustomServiceConfig - customize the service config
                       using this parameter to change service defaults, or overwrite
                       rendered information using raw OpenStack config format. The

--- a/config/samples/heat_v1beta1_heat.yaml
+++ b/config/samples/heat_v1beta1_heat.yaml
@@ -3,24 +3,23 @@ kind: Heat
 metadata:
   name: heat
 spec:
-  customServiceConfig: "# add your customization here"
+  customServiceConfig: |
+    [DEFAULT]
+    debug=True
   databaseInstance: openstack
   databaseUser: "heat"
   rabbitMqClusterName: rabbitmq
   debug:
     dbSync: false
   heatAPI:
-    customServiceConfig: "# add your customization here"
     debug:
       service: false
     resources: {}
   heatCfnAPI:
-    customServiceConfig: "# add your customization here"
     debug:
       service: false
     resources: {}
   heatEngine:
-    customServiceConfig: "# add your customization here"
     debug:
       service: false
     resources: {}

--- a/controllers/heatapi_controller.go
+++ b/controllers/heatapi_controller.go
@@ -622,8 +622,10 @@ func (r *HeatAPIReconciler) generateServiceConfigMaps(
 
 	// customData hold any customization for the service.
 	// custom.conf is going to /etc/heat/heat.conf.d
-	// TODO: make sure custom.conf can not be overwritten
-	customData := map[string]string{common.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig}
+	customData := map[string]string{}
+	if instance.Spec.CustomServiceConfig != "" {
+		customData[common.CustomServiceConfigFileName] = instance.Spec.CustomServiceConfig}
+	}
 
 	for key, data := range instance.Spec.DefaultConfigOverwrite {
 		customData[key] = data

--- a/controllers/heatcfnapi_controller.go
+++ b/controllers/heatcfnapi_controller.go
@@ -627,7 +627,10 @@ func (r *HeatCfnAPIReconciler) generateServiceConfigMaps(
 	// customData hold any customization for the service.
 	// custom.conf is going to /etc/heat/heat.conf.d
 	// TODO: make sure custom.conf can not be overwritten
-	customData := map[string]string{common.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig}
+	customData := map[string]string{}
+	if instance.Spec.CustomServiceConfig != "" {
+		customData[common.CustomServiceConfigFileName] = instance.Spec.CustomServiceConfig}
+	}
 
 	for key, data := range instance.Spec.DefaultConfigOverwrite {
 		customData[key] = data

--- a/controllers/heatengine_controller.go
+++ b/controllers/heatengine_controller.go
@@ -469,8 +469,10 @@ func (r *HeatEngineReconciler) generateServiceConfigMaps(
 
 	// customData hold any customization for the service.
 	// custom.conf is going to /etc/heat/heat.conf.d
-	// TODO: make sure custom.conf can not be overwritten
-	customData := map[string]string{common.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig}
+	customData := map[string]string{}
+	if instance.Spec.CustomServiceConfig != "" {
+		customData[common.CustomServiceConfigFileName] = instance.Spec.CustomServiceConfig}
+	}
 
 	for key, data := range instance.Spec.DefaultConfigOverwrite {
 		customData[key] = data

--- a/tests/kuttl/common/assert-sample-deployment.yaml
+++ b/tests/kuttl/common/assert-sample-deployment.yaml
@@ -13,7 +13,9 @@ kind: Heat
 metadata:
   name: heat
 spec:
-  customServiceConfig: "# add your customization here"
+  customServiceConfig: |
+    [DEFAULT]
+    debug=True
   databaseInstance: openstack
   databaseUser: "heat"
   rabbitMqClusterName: rabbitmq
@@ -21,21 +23,21 @@ spec:
     dbSync: false
   heatAPI:
     containerImage: "quay.io/podified-antelope-centos9/openstack-heat-api:current-podified"
-    customServiceConfig: "# add your customization here"
+    customServiceConfig: ""
     debug:
       service: false
     replicas: 1
     resources: {}
   heatCfnAPI:
     containerImage: "quay.io/podified-antelope-centos9/openstack-heat-api-cfn:current-podified"
-    customServiceConfig: "# add your customization here"
+    customServiceConfig: ""
     debug:
       service: false
     replicas: 1
     resources: {}
   heatEngine:
     containerImage: "quay.io/podified-antelope-centos9/openstack-heat-engine:current-podified"
-    customServiceConfig: "# add your customization here"
+    customServiceConfig: ""
     debug:
       service: false
     replicas: 1
@@ -68,7 +70,7 @@ metadata:
       name: heat
 spec:
   containerImage: quay.io/podified-antelope-centos9/openstack-heat-api:current-podified
-  customServiceConfig: "# add your customization here"
+  customServiceConfig: ""
   databaseHostname: openstack
   databaseUser: heat
   debug:
@@ -100,7 +102,7 @@ metadata:
       name: heat
 spec:
   containerImage: quay.io/podified-antelope-centos9/openstack-heat-api-cfn:current-podified
-  customServiceConfig: "# add your customization here"
+  customServiceConfig: ""
   databaseHostname: openstack
   databaseUser: heat
   debug:
@@ -132,7 +134,7 @@ metadata:
       name: heat
 spec:
   containerImage: quay.io/podified-antelope-centos9/openstack-heat-engine:current-podified
-  customServiceConfig: "# add your customization here"
+  customServiceConfig: ""
   databaseHostname: openstack
   databaseUser: heat
   debug:


### PR DESCRIPTION
Currently CustomServiceConfig at top-layer and each sub CR layer are independent and users have to configure all fields to add the same config settings to all services.