### PR TITLE
Fix override of CustomServiceConfig

### DIFF
--- a/api/bases/heat.openstack.org_heatapis.yaml
+++ b/api/bases/heat.openstack.org_heatapis.yaml
@@ -48,7 +48,6 @@ spec:
                 description: ContainerImage - Container Image URL
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets

--- a/api/bases/heat.openstack.org_heatcfnapis.yaml
+++ b/api/bases/heat.openstack.org_heatcfnapis.yaml
@@ -48,7 +48,6 @@ spec:
                 description: ContainerImage - Container Image URL
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets

--- a/api/bases/heat.openstack.org_heatengines.yaml
+++ b/api/bases/heat.openstack.org_heatengines.yaml
@@ -48,7 +48,6 @@ spec:
                 description: ContainerImage - Container Image URL
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets

--- a/api/bases/heat.openstack.org_heats.yaml
+++ b/api/bases/heat.openstack.org_heats.yaml
@@ -89,7 +89,6 @@ spec:
                     description: ContainerImage - Container Image URL
                     type: string
                   customServiceConfig:
-                    default: '# add your customization here'
                     description: CustomServiceConfig - customize the service config
                       using this parameter to change service defaults, or overwrite
                       rendered information using raw OpenStack config format. The
@@ -187,7 +186,6 @@ spec:
                     description: ContainerImage - Container Image URL
                     type: string
                   customServiceConfig:
-                    default: '# add your customization here'
                     description: CustomServiceConfig - customize the service config
                       using this parameter to change service defaults, or overwrite
                       rendered information using raw OpenStack config format. The
@@ -285,7 +283,6 @@ spec:
                     description: ContainerImage - Container Image URL
                     type: string
                   customServiceConfig:
-                    default: '# add your customization here'
                     description: CustomServiceConfig - customize the service config
                       using this parameter to change service defaults, or overwrite
                       rendered information using raw OpenStack config format. The

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -72,11 +72,10 @@ type HeatServiceTemplate struct {
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="# add your customization here"
 	// CustomServiceConfig - customize the service config using this parameter to change service defaults,
 	// or overwrite rendered information using raw OpenStack config format. The content gets added to
 	// to /etc/<service>/<service>.conf.d directory as custom.conf file.
-	CustomServiceConfig string `json:"customServiceConfig"`
+	CustomServiceConfig string `json:"customServiceConfig,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// ConfigOverwrite - interface to overwrite default config files like e.g. policy.json.

--- a/config/crd/bases/heat.openstack.org_heatapis.yaml
+++ b/config/crd/bases/heat.openstack.org_heatapis.yaml
@@ -48,7 +48,6 @@ spec:
                 description: ContainerImage - Container Image URL
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets

--- a/config/crd/bases/heat.openstack.org_heatcfnapis.yaml
+++ b/config/crd/bases/heat.openstack.org_heatcfnapis.yaml
@@ -48,7 +48,6 @@ spec:
                 description: ContainerImage - Container Image URL
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets

--- a/config/crd/bases/heat.openstack.org_heatengines.yaml
+++ b/config/crd/bases/heat.openstack.org_heatengines.yaml
@@ -48,7 +48,6 @@ spec:
                 description: ContainerImage - Container Image URL
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets

--- a/config/crd/bases/heat.openstack.org_heats.yaml
+++ b/config/crd/bases/heat.openstack.org_heats.yaml
@@ -89,7 +89,6 @@ spec:
                     description: ContainerImage - Container Image URL
                     type: string
                   customServiceConfig:
-                    default: '# add your customization here'
                     description: CustomServiceConfig - customize the service config
                       using this parameter to change service defaults, or overwrite
                       rendered information using raw OpenStack config format. The
@@ -187,7 +186,6 @@ spec:
                     description: ContainerImage - Container Image URL
                     type: string
                   customServiceConfig:
-                    default: '# add your customization here'
                     description: CustomServiceConfig - customize the service config
                       using this parameter to change service defaults, or overwrite
                       rendered information using raw OpenStack config format. The
@@ -285,7 +283,6 @@ spec:
                     description: ContainerImage - Container Image URL
                     type: string
                   customServiceConfig:
-                    default: '# add your customization here'
                     description: CustomServiceConfig - customize the service config
                       using this parameter to change service defaults, or overwrite
                       rendered information using raw OpenStack config format. The

--- a/config/samples/heat_v1beta1_heat.yaml
+++ b/config/samples/heat_v1beta1_heat.yaml
@@ -3,24 +3,23 @@ kind: Heat
 metadata:
   name: heat
 spec:
-  customServiceConfig: "# add your customization here"
+  customServiceConfig: |
+    [DEFAULT]
+    debug=True
   databaseInstance: openstack
   databaseUser: "heat"
   rabbitMqClusterName: rabbitmq
   debug:
     dbSync: false
   heatAPI:
-    customServiceConfig: "# add your customization here"
     debug:
       service: false
     resources: {}
   heatCfnAPI:
-    customServiceConfig: "# add your customization here"
     debug:
       service: false
     resources: {}
   heatEngine:
-    customServiceConfig: "# add your customization here"
     debug:
       service: false
     resources: {}

--- a/controllers/heat_controller.go
+++ b/controllers/heat_controller.go
@@ -796,7 +796,7 @@ func (r *HeatReconciler) generateServiceConfigMaps(
 	// custom.conf is going to /etc/heat/heat.conf.d
 	// all other files get placed into /etc/heat to allow overwrite of e.g. policy.json
 	// TODO: make sure custom.conf can not be overwritten
-	customData := map[string]string{common.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig}
+	customData := map[string]string{heat.CustomConfigFileName: instance.Spec.CustomServiceConfig}
 	for key, data := range instance.Spec.DefaultConfigOverwrite {
 		customData[key] = data
 	}

--- a/controllers/heatapi_controller.go
+++ b/controllers/heatapi_controller.go
@@ -623,13 +623,10 @@ func (r *HeatAPIReconciler) generateServiceConfigMaps(
 	// customData hold any customization for the service.
 	// custom.conf is going to /etc/heat/heat.conf.d
 	// TODO: make sure custom.conf can not be overwritten
-	customData := map[string]string{common.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig}
-
+	customData := map[string]string{heat.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig}
 	for key, data := range instance.Spec.DefaultConfigOverwrite {
 		customData[key] = data
 	}
-
-	customData[common.CustomServiceConfigFileName] = instance.Spec.CustomServiceConfig
 
 	cms := []util.Template{
 		// Custom ConfigMap

--- a/controllers/heatcfnapi_controller.go
+++ b/controllers/heatcfnapi_controller.go
@@ -627,13 +627,10 @@ func (r *HeatCfnAPIReconciler) generateServiceConfigMaps(
 	// customData hold any customization for the service.
 	// custom.conf is going to /etc/heat/heat.conf.d
 	// TODO: make sure custom.conf can not be overwritten
-	customData := map[string]string{common.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig}
-
+	customData := map[string]string{heat.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig}
 	for key, data := range instance.Spec.DefaultConfigOverwrite {
 		customData[key] = data
 	}
-
-	customData[common.CustomServiceConfigFileName] = instance.Spec.CustomServiceConfig
 
 	cms := []util.Template{
 		// Custom ConfigMap

--- a/controllers/heatengine_controller.go
+++ b/controllers/heatengine_controller.go
@@ -469,14 +469,10 @@ func (r *HeatEngineReconciler) generateServiceConfigMaps(
 
 	// customData hold any customization for the service.
 	// custom.conf is going to /etc/heat/heat.conf.d
-	// TODO: make sure custom.conf can not be overwritten
-	customData := map[string]string{common.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig}
-
+	customData := map[string]string{heat.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig}
 	for key, data := range instance.Spec.DefaultConfigOverwrite {
 		customData[key] = data
 	}
-
-	customData[common.CustomServiceConfigFileName] = instance.Spec.CustomServiceConfig
 
 	cms := []util.Template{
 		// Custom ConfigMap

--- a/pkg/heat/const.go
+++ b/pkg/heat/const.go
@@ -30,6 +30,12 @@ const (
 	StackDomainName = "heat_stack"
 	// DatabaseName -
 	DatabaseName = "heat"
+	// DefaultsConfigFileName -
+	DefaultsConfigFileName = "00-config.conf"
+	// CustomConfigFileName -
+	CustomConfigFileName = "01-config.conf"
+	// CustomServiceConfigFileName -
+	CustomServiceConfigFileName = "02-config.conf"
 	// HeatPublicPort -
 	HeatPublicPort int32 = 8004
 	// HeatInternalPort -

--- a/templates/heat/config/db-sync-config.json
+++ b/templates/heat/config/db-sync-config.json
@@ -8,8 +8,8 @@
       "perm": "0600"
     },
     {
-      "source": "/var/lib/config-data/merged/custom.conf",
-      "dest": "/etc/heat/heat.conf.d/custom.conf",
+      "source": "/var/lib/config-data/merged/02-config.conf",
+      "dest": "/etc/heat/heat.conf.d/02-config.conf",
       "owner": "heat",
       "perm": "0600"
     }

--- a/templates/heat/config/heat-engine-config.json
+++ b/templates/heat/config/heat-engine-config.json
@@ -9,8 +9,15 @@
       "perm": "0644"
     },
     {
-      "source": "/var/lib/config-data/merged/custom.conf",
-      "dest": "/etc/heat/heat.conf.d/custom.conf",
+      "source": "/var/lib/config-data/merged/02-config.conf.conf",
+      "dest": "/etc/heat/heat.conf.d/02-config.conf.conf",
+      "merge": false,
+      "preserve_properties": true,
+      "perm": "0644"
+    },
+    {
+      "source": "/var/lib/config-data/merged/03-config.conf.conf",
+      "dest": "/etc/heat/heat.conf.d/03-config.conf.conf",
       "merge": false,
       "preserve_properties": true,
       "perm": "0644"

--- a/templates/heat/config/heatapi-config.json
+++ b/templates/heat/config/heatapi-config.json
@@ -9,8 +9,15 @@
       "perm": "0644"
     },
     {
-      "source": "/var/lib/config-data/merged/custom.conf",
-      "dest": "/etc/heat/heat.conf.d/custom.conf",
+      "source": "/var/lib/config-data/merged/02-config.conf.conf",
+      "dest": "/etc/heat/heat.conf.d/02-config.conf.conf",
+      "merge": false,
+      "preserve_properties": true,
+      "perm": "0644"
+    },
+    {
+      "source": "/var/lib/config-data/merged/03-config.conf.conf",
+      "dest": "/etc/heat/heat.conf.d/03-config.conf.conf",
       "merge": false,
       "preserve_properties": true,
       "perm": "0644"

--- a/templates/heat/config/heatcfnapi-config.json
+++ b/templates/heat/config/heatcfnapi-config.json
@@ -9,8 +9,15 @@
       "perm": "0644"
     },
     {
-      "source": "/var/lib/config-data/merged/custom.conf",
-      "dest": "/etc/heat/heat.conf.d/custom.conf",
+      "source": "/var/lib/config-data/merged/02-config.conf.conf",
+      "dest": "/etc/heat/heat.conf.d/02-config.conf.conf",
+      "merge": false,
+      "preserve_properties": true,
+      "perm": "0644"
+    },
+    {
+      "source": "/var/lib/config-data/merged/03-config.conf.conf",
+      "dest": "/etc/heat/heat.conf.d/03-config.conf.conf",
       "merge": false,
       "preserve_properties": true,
       "perm": "0644"

--- a/tests/kuttl/common/assert-sample-deployment.yaml
+++ b/tests/kuttl/common/assert-sample-deployment.yaml
@@ -13,7 +13,9 @@ kind: Heat
 metadata:
   name: heat
 spec:
-  customServiceConfig: "# add your customization here"
+  customServiceConfig: |
+    [DEFAULT]
+    debug=True
   databaseInstance: openstack
   databaseUser: "heat"
   rabbitMqClusterName: rabbitmq
@@ -21,21 +23,21 @@ spec:
     dbSync: false
   heatAPI:
     containerImage: "quay.io/podified-antelope-centos9/openstack-heat-api:current-podified"
-    customServiceConfig: "# add your customization here"
+    customServiceConfig: ""
     debug:
       service: false
     replicas: 1
     resources: {}
   heatCfnAPI:
     containerImage: "quay.io/podified-antelope-centos9/openstack-heat-api-cfn:current-podified"
-    customServiceConfig: "# add your customization here"
+    customServiceConfig: ""
     debug:
       service: false
     replicas: 1
     resources: {}
   heatEngine:
     containerImage: "quay.io/podified-antelope-centos9/openstack-heat-engine:current-podified"
-    customServiceConfig: "# add your customization here"
+    customServiceConfig: ""
     debug:
       service: false
     replicas: 1
@@ -68,7 +70,7 @@ metadata:
       name: heat
 spec:
   containerImage: quay.io/podified-antelope-centos9/openstack-heat-api:current-podified
-  customServiceConfig: "# add your customization here"
+  customServiceConfig: ""
   databaseHostname: openstack
   databaseUser: heat
   debug:
@@ -100,7 +102,7 @@ metadata:
       name: heat
 spec:
   containerImage: quay.io/podified-antelope-centos9/openstack-heat-api-cfn:current-podified
-  customServiceConfig: "# add your customization here"
+  customServiceConfig: ""
   databaseHostname: openstack
   databaseUser: heat
   debug:
@@ -132,7 +134,7 @@ metadata:
       name: heat
 spec:
   containerImage: quay.io/podified-antelope-centos9/openstack-heat-engine:current-podified
-  customServiceConfig: "# add your customization here"
+  customServiceConfig: ""
   databaseHostname: openstack
   databaseUser: heat
   debug:


### PR DESCRIPTION
Currently CustomServiceConfig at top-layer and each sub CR layer are independent and users have to configure all fields to add the same config settings to all services.

This fixes that behavior and ensures the top-level CustomServiceConfig is used even when the sub-level CustomServiceConfig is used.