### PR TITLE
Replace HeatRabbitMqTransportURLReady by common condition

### DIFF
--- a/api/v1beta1/conditions.go
+++ b/api/v1beta1/conditions.go
@@ -29,9 +29,6 @@ const (
 	// HeatEngineReadyCondition ...
 	HeatEngineReadyCondition condition.Type = "HeatEngineReady"
 
-	// HeatRabbitMqTransportURLReadyCondition Status=True condition which indicates if the RabbitMQ TransportURLUrl is ready
-	HeatRabbitMqTransportURLReadyCondition condition.Type = "HeatRabbitMqTransportURLReady"
-
 	// HeatStackDomainReadyCondition ...
 	HeatStackDomainReadyCondition condition.Type = "HeatStackDomainReady"
 )
@@ -64,21 +61,6 @@ const (
 
 	// HeatEngineReadyErrorMessage ...
 	HeatEngineReadyErrorMessage = "HeatEngine error occured %s"
-
-	//
-	// HeatRabbitMqTransportURLReady condition messages
-	//
-	// HeatRabbitMqTransportURLReadyInitMessage
-	HeatRabbitMqTransportURLReadyInitMessage = "HeatRabbitMqTransportURL not started"
-
-	// HeatRabbitMqTransportURLReadyRunningMessage
-	HeatRabbitMqTransportURLReadyRunningMessage = "HeatRabbitMqTransportURL creation in progress"
-
-	// HeatRabbitMqTransportURLReadyMessage
-	HeatRabbitMqTransportURLReadyMessage = "HeatRabbitMqTransportURL successfully created"
-
-	// HeatRabbitMqTransportURLReadyErrorMessage
-	HeatRabbitMqTransportURLReadyErrorMessage = "HeatRabbitMqTransportURL error occured %s"
 
 	//
 	// HeatStackDomainReady condition messages

--- a/controllers/heat_controller.go
+++ b/controllers/heat_controller.go
@@ -155,13 +155,13 @@ func (r *HeatReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 		cl := condition.CreateList(
 			condition.UnknownCondition(condition.DBReadyCondition, condition.InitReason, condition.DBReadyInitMessage),
 			condition.UnknownCondition(condition.DBSyncReadyCondition, condition.InitReason, condition.DBSyncReadyInitMessage),
+			condition.UnknownCondition(condition.RabbitMqTransportURLReadyCondition, condition.InitReason, condition.RabbitMqTransportURLReadyInitMessage),
 			condition.UnknownCondition(condition.InputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
 			condition.UnknownCondition(condition.ServiceConfigReadyCondition, condition.InitReason, condition.ServiceConfigReadyInitMessage),
 			condition.UnknownCondition(heatv1beta1.HeatStackDomainReadyCondition, condition.InitReason, heatv1beta1.HeatStackDomainReadyInitMessage),
 			condition.UnknownCondition(heatv1beta1.HeatAPIReadyCondition, condition.InitReason, heatv1beta1.HeatAPIReadyInitMessage),
 			condition.UnknownCondition(heatv1beta1.HeatCfnAPIReadyCondition, condition.InitReason, heatv1beta1.HeatCfnAPIReadyInitMessage),
 			condition.UnknownCondition(heatv1beta1.HeatEngineReadyCondition, condition.InitReason, heatv1beta1.HeatEngineReadyInitMessage),
-			condition.UnknownCondition(heatv1beta1.HeatRabbitMqTransportURLReadyCondition, condition.InitReason, heatv1beta1.HeatRabbitMqTransportURLReadyInitMessage),
 			// service account, role, rolebinding conditions
 			condition.UnknownCondition(condition.ServiceAccountReadyCondition, condition.InitReason, condition.ServiceAccountReadyInitMessage),
 			condition.UnknownCondition(condition.RoleReadyCondition, condition.InitReason, condition.RoleReadyInitMessage),
@@ -336,10 +336,10 @@ func (r *HeatReconciler) reconcileNormal(ctx context.Context, instance *heatv1be
 
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
-			heatv1beta1.HeatRabbitMqTransportURLReadyCondition,
+			condition.RabbitMqTransportURLReadyCondition,
 			condition.ErrorReason,
 			condition.SeverityWarning,
-			heatv1beta1.HeatRabbitMqTransportURLReadyErrorMessage,
+			condition.RabbitMqTransportURLReadyErrorMessage,
 			err.Error()))
 		return ctrl.Result{}, err
 	}
@@ -354,10 +354,10 @@ func (r *HeatReconciler) reconcileNormal(ctx context.Context, instance *heatv1be
 		r.Log.Info(fmt.Sprintf("Waiting for TransportURL %s secret to be created", transportURL.Name))
 
 		instance.Status.Conditions.Set(condition.FalseCondition(
-			heatv1beta1.HeatRabbitMqTransportURLReadyCondition,
+			condition.RabbitMqTransportURLReadyCondition,
 			condition.RequestedReason,
 			condition.SeverityInfo,
-			heatv1beta1.HeatRabbitMqTransportURLReadyRunningMessage))
+			condition.RabbitMqTransportURLReadyRunningMessage))
 
 		return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, nil
 	}
@@ -370,17 +370,17 @@ func (r *HeatReconciler) reconcileNormal(ctx context.Context, instance *heatv1be
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
 			instance.Status.Conditions.Set(condition.FalseCondition(
-				heatv1beta1.HeatRabbitMqTransportURLReadyCondition,
+				condition.RabbitMqTransportURLReadyCondition,
 				condition.RequestedReason,
 				condition.SeverityInfo,
-				heatv1beta1.HeatRabbitMqTransportURLReadyRunningMessage))
+				condition.RabbitMqTransportURLReadyRunningMessage))
 			return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, fmt.Errorf("TransportURL secret %s not found", instance.Status.TransportURLSecret)
 		}
 		instance.Status.Conditions.Set(condition.FalseCondition(
-			heatv1beta1.HeatRabbitMqTransportURLReadyCondition,
+			condition.RabbitMqTransportURLReadyCondition,
 			condition.ErrorReason,
 			condition.SeverityWarning,
-			heatv1beta1.HeatRabbitMqTransportURLReadyErrorMessage,
+			condition.RabbitMqTransportURLReadyErrorMessage,
 			err.Error()))
 		return ctrl.Result{}, err
 	}
@@ -388,7 +388,7 @@ func (r *HeatReconciler) reconcileNormal(ctx context.Context, instance *heatv1be
 
 	// run check TransportURL secret - end
 
-	instance.Status.Conditions.MarkTrue(heatv1beta1.HeatRabbitMqTransportURLReadyCondition, heatv1beta1.HeatRabbitMqTransportURLReadyMessage)
+	instance.Status.Conditions.MarkTrue(condition.RabbitMqTransportURLReadyCondition, condition.RabbitMqTransportURLReadyMessage)
 
 	//
 	// Create ConfigMaps and Secrets required as input for the Service and calculate an overall hash of hashes

--- a/tests/functional/heat_controller_test.go
+++ b/tests/functional/heat_controller_test.go
@@ -95,7 +95,7 @@ var _ = Describe("Heat controller", func() {
 			)
 
 			for _, cond := range []condition.Type{
-				heatv1.HeatRabbitMqTransportURLReadyCondition,
+				condition.RabbitMqTransportURLReadyCondition,
 				condition.ServiceConfigReadyCondition,
 				condition.DBReadyCondition,
 				condition.DBSyncReadyCondition,
@@ -149,7 +149,7 @@ var _ = Describe("Heat controller", func() {
 			th.ExpectCondition(
 				heatName,
 				ConditionGetterFunc(HeatConditionGetter),
-				heatv1.HeatRabbitMqTransportURLReadyCondition,
+				condition.RabbitMqTransportURLReadyCondition,
 				corev1.ConditionFalse,
 			)
 			th.ExpectCondition(
@@ -185,7 +185,7 @@ var _ = Describe("Heat controller", func() {
 			th.ExpectCondition(
 				heatName,
 				ConditionGetterFunc(HeatConditionGetter),
-				heatv1.HeatRabbitMqTransportURLReadyCondition,
+				condition.RabbitMqTransportURLReadyCondition,
 				corev1.ConditionTrue,
 			)
 			th.ExpectCondition(


### PR DESCRIPTION
We have added the common RabbitMqTransportURLReady to lib-common to reduce duplicate implementations.

Depends-on: https://github.com/openstack-k8s-operators/lib-common/pull/300