### PR TITLE
Enable debug log for heat services

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The following is taken from the Sample config in this repo:
 
 ```yaml
 spec:
-  customServiceConfig: "# add your customization here"
+  customServiceConfig: ""
   databaseInstance: openstack
   databaseUser: "heat"
   rabbitMqClusterName: rabbitmq
@@ -25,21 +25,21 @@ spec:
     dbSync: false
   heatAPI:
     containerImage: "quay.io/podified-antelope-centos9/openstack-heat-api:current-podified"
-    customServiceConfig: "# add your customization here"
+    customServiceConfig: ""
     debug:
       service: false
     replicas: 1
     resources: {}
   heatCfnAPI:
     containerImage: "quay.io/podified-antelope-centos9/openstack-heat-api-cfn:current-podified"
-    customServiceConfig: "# add your customization here"
+    customServiceConfig: ""
     debug:
       service: false
     replicas: 1
     resources: {}
   heatEngine:
     containerImage: "quay.io/podified-antelope-centos9/openstack-heat-engine:current-podified"
-    customServiceConfig: "# add your customization here"
+    customServiceConfig: ""
     debug:
       service: false
     replicas: 1
@@ -95,7 +95,7 @@ The following snippet is taken from the `OpenStackControlPlane` Custom Resource:
 ❯ oc get openstackcontrolplane openstack -o yaml | yq .spec.heat
 enabled: true #<-- This needs to be set to true for Heat to be deployed
 template:
-  customServiceConfig: '# add your customization here'
+  customServiceConfig: ''
   databaseInstance: openstack
   databaseUser: heat
   debug:

--- a/api/bases/heat.openstack.org_heatapis.yaml
+++ b/api/bases/heat.openstack.org_heatapis.yaml
@@ -48,7 +48,6 @@ spec:
                 description: ContainerImage - Container Image URL
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets

--- a/api/bases/heat.openstack.org_heatcfnapis.yaml
+++ b/api/bases/heat.openstack.org_heatcfnapis.yaml
@@ -48,7 +48,6 @@ spec:
                 description: ContainerImage - Container Image URL
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets

--- a/api/bases/heat.openstack.org_heatengines.yaml
+++ b/api/bases/heat.openstack.org_heatengines.yaml
@@ -48,7 +48,6 @@ spec:
                 description: ContainerImage - Container Image URL
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets

--- a/api/bases/heat.openstack.org_heats.yaml
+++ b/api/bases/heat.openstack.org_heats.yaml
@@ -45,7 +45,6 @@ spec:
             description: HeatSpec defines the desired state of Heat
             properties:
               customServiceConfig:
-                default: '# add your customization here'
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets
@@ -89,7 +88,6 @@ spec:
                     description: ContainerImage - Container Image URL
                     type: string
                   customServiceConfig:
-                    default: '# add your customization here'
                     description: CustomServiceConfig - customize the service config
                       using this parameter to change service defaults, or overwrite
                       rendered information using raw OpenStack config format. The
@@ -187,7 +185,6 @@ spec:
                     description: ContainerImage - Container Image URL
                     type: string
                   customServiceConfig:
-                    default: '# add your customization here'
                     description: CustomServiceConfig - customize the service config
                       using this parameter to change service defaults, or overwrite
                       rendered information using raw OpenStack config format. The
@@ -285,7 +282,6 @@ spec:
                     description: ContainerImage - Container Image URL
                     type: string
                   customServiceConfig:
-                    default: '# add your customization here'
                     description: CustomServiceConfig - customize the service config
                       using this parameter to change service defaults, or overwrite
                       rendered information using raw OpenStack config format. The

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -72,11 +72,10 @@ type HeatServiceTemplate struct {
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="# add your customization here"
 	// CustomServiceConfig - customize the service config using this parameter to change service defaults,
 	// or overwrite rendered information using raw OpenStack config format. The content gets added to
 	// to /etc/<service>/<service>.conf.d directory as custom.conf file.
-	CustomServiceConfig string `json:"customServiceConfig"`
+	CustomServiceConfig string `json:"customServiceConfig,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// ConfigOverwrite - interface to overwrite default config files like e.g. policy.json.

--- a/api/v1beta1/heat_types.go
+++ b/api/v1beta1/heat_types.go
@@ -60,11 +60,10 @@ type HeatSpec struct {
 	PreserveJobs bool `json:"preserveJobs"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="# add your customization here"
 	// CustomServiceConfig - customize the service config using this parameter to change service defaults,
 	// or overwrite rendered information using raw OpenStack config format. The content gets added to
 	// to /etc/<service>/<service>.conf.d directory as custom.conf file.
-	CustomServiceConfig string `json:"customServiceConfig"`
+	CustomServiceConfig string `json:"customServiceConfig,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// ConfigOverwrite - interface to overwrite default config files like e.g. policy.json.

--- a/config/crd/bases/heat.openstack.org_heatapis.yaml
+++ b/config/crd/bases/heat.openstack.org_heatapis.yaml
@@ -48,7 +48,6 @@ spec:
                 description: ContainerImage - Container Image URL
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets

--- a/config/crd/bases/heat.openstack.org_heatcfnapis.yaml
+++ b/config/crd/bases/heat.openstack.org_heatcfnapis.yaml
@@ -48,7 +48,6 @@ spec:
                 description: ContainerImage - Container Image URL
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets

--- a/config/crd/bases/heat.openstack.org_heatengines.yaml
+++ b/config/crd/bases/heat.openstack.org_heatengines.yaml
@@ -48,7 +48,6 @@ spec:
                 description: ContainerImage - Container Image URL
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets

--- a/config/crd/bases/heat.openstack.org_heats.yaml
+++ b/config/crd/bases/heat.openstack.org_heats.yaml
@@ -45,7 +45,6 @@ spec:
             description: HeatSpec defines the desired state of Heat
             properties:
               customServiceConfig:
-                default: '# add your customization here'
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets
@@ -89,7 +88,6 @@ spec:
                     description: ContainerImage - Container Image URL
                     type: string
                   customServiceConfig:
-                    default: '# add your customization here'
                     description: CustomServiceConfig - customize the service config
                       using this parameter to change service defaults, or overwrite
                       rendered information using raw OpenStack config format. The
@@ -187,7 +185,6 @@ spec:
                     description: ContainerImage - Container Image URL
                     type: string
                   customServiceConfig:
-                    default: '# add your customization here'
                     description: CustomServiceConfig - customize the service config
                       using this parameter to change service defaults, or overwrite
                       rendered information using raw OpenStack config format. The
@@ -285,7 +282,6 @@ spec:
                     description: ContainerImage - Container Image URL
                     type: string
                   customServiceConfig:
-                    default: '# add your customization here'
                     description: CustomServiceConfig - customize the service config
                       using this parameter to change service defaults, or overwrite
                       rendered information using raw OpenStack config format. The

--- a/config/samples/heat_v1beta1_heat.yaml
+++ b/config/samples/heat_v1beta1_heat.yaml
@@ -3,24 +3,23 @@ kind: Heat
 metadata:
   name: heat
 spec:
-  customServiceConfig: "# add your customization here"
+  customServiceConfig: |
+    [DEFAULT]
+    debug = True
   databaseInstance: openstack
   databaseUser: "heat"
   rabbitMqClusterName: rabbitmq
   debug:
     dbSync: false
   heatAPI:
-    customServiceConfig: "# add your customization here"
     debug:
       service: false
     resources: {}
   heatCfnAPI:
-    customServiceConfig: "# add your customization here"
     debug:
       service: false
     resources: {}
   heatEngine:
-    customServiceConfig: "# add your customization here"
     debug:
       service: false
     resources: {}

--- a/tests/kuttl/common/assert-sample-deployment.yaml
+++ b/tests/kuttl/common/assert-sample-deployment.yaml
@@ -13,7 +13,9 @@ kind: Heat
 metadata:
   name: heat
 spec:
-  customServiceConfig: "# add your customization here"
+  customServiceConfig: |
+    [DEFAULT]
+    debug = True
   databaseInstance: openstack
   databaseUser: "heat"
   rabbitMqClusterName: rabbitmq
@@ -21,21 +23,18 @@ spec:
     dbSync: false
   heatAPI:
     containerImage: "quay.io/podified-antelope-centos9/openstack-heat-api:current-podified"
-    customServiceConfig: "# add your customization here"
     debug:
       service: false
     replicas: 1
     resources: {}
   heatCfnAPI:
     containerImage: "quay.io/podified-antelope-centos9/openstack-heat-api-cfn:current-podified"
-    customServiceConfig: "# add your customization here"
     debug:
       service: false
     replicas: 1
     resources: {}
   heatEngine:
     containerImage: "quay.io/podified-antelope-centos9/openstack-heat-engine:current-podified"
-    customServiceConfig: "# add your customization here"
     debug:
       service: false
     replicas: 1
@@ -68,7 +67,6 @@ metadata:
       name: heat
 spec:
   containerImage: quay.io/podified-antelope-centos9/openstack-heat-api:current-podified
-  customServiceConfig: "# add your customization here"
   databaseHostname: openstack
   databaseUser: heat
   debug:
@@ -100,7 +98,6 @@ metadata:
       name: heat
 spec:
   containerImage: quay.io/podified-antelope-centos9/openstack-heat-api-cfn:current-podified
-  customServiceConfig: "# add your customization here"
   databaseHostname: openstack
   databaseUser: heat
   debug:
@@ -132,7 +129,6 @@ metadata:
       name: heat
 spec:
   containerImage: quay.io/podified-antelope-centos9/openstack-heat-engine:current-podified
-  customServiceConfig: "# add your customization here"
   databaseHostname: openstack
   databaseUser: heat
   debug:


### PR DESCRIPTION
... so that we can check behavior of heat services more closely in CI. This also removes the default value for customServiceConfig following the other operators.