### PR TITLE
Bump k8s version in envtest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ DEFAULT_IMG ?= quay.io/openstack-k8s-operators/heat-operator:latest
 IMG ?= $(DEFAULT_IMG)
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.25.0
+ENVTEST_K8S_VERSION = 1.26
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))


### PR DESCRIPTION
... to the one consistent with the version in dependencies.

This omits the bug fix version so that the latest one of the 1.26 release is selected.