### PR TITLE
switch to structured logging

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"os"
 	"strings"
@@ -120,8 +121,7 @@ func main() {
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
 		Kclient: kclient,
-		Log:     ctrl.Log.WithName("controllers").WithName("Heat"),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, context.Background()); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Heat")
 		os.Exit(1)
 	}
@@ -130,8 +130,7 @@ func main() {
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
 		Kclient: kclient,
-		Log:     ctrl.Log.WithName("controllers").WithName("HeatAPI"),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, context.Background()); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "HeatAPI")
 		os.Exit(1)
 	}
@@ -140,8 +139,7 @@ func main() {
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
 		Kclient: kclient,
-		Log:     ctrl.Log.WithName("controllers").WithName("HeatCfnAPI"),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, context.Background()); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "HeatCfnAPI")
 		os.Exit(1)
 	}
@@ -150,8 +148,7 @@ func main() {
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
 		Kclient: kclient,
-		Log:     ctrl.Log.WithName("controllers").WithName("HeatEngine"),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, context.Background()); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "HeatEngine")
 		os.Exit(1)
 	}


### PR DESCRIPTION
This automatically adds additional fields like reconcile_id etc.. from the controller context.

before :

`2023-05-18T01:53:14+03:00 INFO  controllers.KeystoneAPI Reconciled Service init successfully`

after:

`2023-05-18T02:00:28+03:00       INFO    Controllers.KeystoneAPI Reconciled Service init successfully    {"controller": "keystoneapi", "controllerGroup": "keystone.openstack.org", "controllerKind":"KeystoneAPI", "KeystoneAPI": {"name":"keystone","namespace":"openstack"}, "namespace": "openstack", "name": "keystone", "reconcileID": "512a4d9b-f31d-4fa4-a4cc-cd6c13e4455d"}
`

*by using per reconcile function respective logger objects, the intention is to lay the ground for parallel reconciliation in future and avoid race conditions as ctx objects are reconcile run specific.

*example logs lines  are currently from keystone operator [#220_patch](https://github.com/openstack-k8s-operators/keystone-operator/pull/220) until this operator deployment patch testing  is is done

