### PR TITLE
Remove redundant defaults of PasswordSelector

### DIFF
--- a/api/bases/heat.openstack.org_heatapis.yaml
+++ b/api/bases/heat.openstack.org_heatapis.yaml
@@ -88,10 +88,6 @@ spec:
                   the service
                 type: object
               passwordSelectors:
-                default:
-                  authEncryptionKey: HeatAuthEncryptionKey
-                  database: HeatDatabasePassword
-                  service: HeatPassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
                 properties:

--- a/api/bases/heat.openstack.org_heatcfnapis.yaml
+++ b/api/bases/heat.openstack.org_heatcfnapis.yaml
@@ -88,10 +88,6 @@ spec:
                   the service
                 type: object
               passwordSelectors:
-                default:
-                  authEncryptionKey: HeatAuthEncryptionKey
-                  database: HeatDatabasePassword
-                  service: HeatPassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
                 properties:

--- a/api/bases/heat.openstack.org_heatengines.yaml
+++ b/api/bases/heat.openstack.org_heatengines.yaml
@@ -88,10 +88,6 @@ spec:
                   the service
                 type: object
               passwordSelectors:
-                default:
-                  authEncryptionKey: HeatAuthEncryptionKey
-                  database: HeatDatabasePassword
-                  service: HeatPassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
                 properties:

--- a/api/bases/heat.openstack.org_heats.yaml
+++ b/api/bases/heat.openstack.org_heats.yaml
@@ -378,10 +378,6 @@ spec:
                   the Heat services
                 type: object
               passwordSelectors:
-                default:
-                  authEncryptionKey: HeatAuthEncryptionKey
-                  database: HeatDatabasePassword
-                  service: HeatPassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
                 properties:

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -39,9 +39,8 @@ type HeatTemplate struct {
 	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={database: HeatDatabasePassword, service: HeatPassword, authEncryptionKey: HeatAuthEncryptionKey}
 	// PasswordSelectors - Selectors to identify the DB and ServiceUser password from the Secret
-	PasswordSelectors PasswordSelector `json:"passwordSelectors"`
+	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
 }
 
 // HeatServiceTemplate -
@@ -90,15 +89,15 @@ type PasswordSelector struct {
 	// +kubebuilder:default="HeatDatabasePassword"
 	// Database - Selector to get the heat Database user password from the Secret
 	// TODO: not used, need change in mariadb-operator
-	Database string `json:"database"`
+	Database string `json:"database,omitempty"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="HeatPassword"
 	// Service - Selector to get the heat service password from the Secret
-	Service string `json:"service"`
+	Service string `json:"service,omitempty"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="HeatAuthEncryptionKey"
 	// AuthEncryptionKey - Selector to get the heat auth encryption key from the Secret
-	AuthEncryptionKey string `json:"authEncryptionKey"`
+	AuthEncryptionKey string `json:"authEncryptionKey,omitempty"`
 }
 
 // HeatDebug ...

--- a/config/crd/bases/heat.openstack.org_heatapis.yaml
+++ b/config/crd/bases/heat.openstack.org_heatapis.yaml
@@ -88,10 +88,6 @@ spec:
                   the service
                 type: object
               passwordSelectors:
-                default:
-                  authEncryptionKey: HeatAuthEncryptionKey
-                  database: HeatDatabasePassword
-                  service: HeatPassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
                 properties:

--- a/config/crd/bases/heat.openstack.org_heatcfnapis.yaml
+++ b/config/crd/bases/heat.openstack.org_heatcfnapis.yaml
@@ -88,10 +88,6 @@ spec:
                   the service
                 type: object
               passwordSelectors:
-                default:
-                  authEncryptionKey: HeatAuthEncryptionKey
-                  database: HeatDatabasePassword
-                  service: HeatPassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
                 properties:

--- a/config/crd/bases/heat.openstack.org_heatengines.yaml
+++ b/config/crd/bases/heat.openstack.org_heatengines.yaml
@@ -88,10 +88,6 @@ spec:
                   the service
                 type: object
               passwordSelectors:
-                default:
-                  authEncryptionKey: HeatAuthEncryptionKey
-                  database: HeatDatabasePassword
-                  service: HeatPassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
                 properties:

--- a/config/crd/bases/heat.openstack.org_heats.yaml
+++ b/config/crd/bases/heat.openstack.org_heats.yaml
@@ -378,10 +378,6 @@ spec:
                   the Heat services
                 type: object
               passwordSelectors:
-                default:
-                  authEncryptionKey: HeatAuthEncryptionKey
-                  database: HeatDatabasePassword
-                  service: HeatPassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
                 properties:


### PR DESCRIPTION
We define defaults in two layers but this is redundant. This change attempts to define defaults in the single layer instead.