### PR TITLE
Simplify if else statements

### DIFF
--- a/controllers/heat_controller.go
+++ b/controllers/heat_controller.go
@@ -294,10 +294,8 @@ func (r *HeatReconciler) reconcileNormal(ctx context.Context, instance *heatv1be
 		},
 	}
 	rbacResult, err := common_rbac.ReconcileRbac(ctx, helper, instance, rbacRules)
-	if err != nil {
+	if err != nil || (rbacResult != ctrl.Result{}) {
 		return rbacResult, err
-	} else if (rbacResult != ctrl.Result{}) {
-		return rbacResult, nil
 	}
 
 	// ConfigMap
@@ -437,26 +435,20 @@ func (r *HeatReconciler) reconcileNormal(ctx context.Context, instance *heatv1be
 
 	// Handle service init
 	ctrlResult, err := r.reconcileInit(ctx, instance, helper, serviceLabels)
-	if err != nil {
+	if err != nil || (ctrlResult != ctrl.Result{}) {
 		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
-		return ctrlResult, nil
 	}
 
 	// Handle service update
 	ctrlResult, err = r.reconcileUpdate(ctx, instance, helper)
-	if err != nil {
+	if err != nil || (ctrlResult != ctrl.Result{}) {
 		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
-		return ctrlResult, nil
 	}
 
 	// Handle service upgrade
 	ctrlResult, err = r.reconcileUpgrade(ctx, instance, helper)
-	if err != nil {
+	if err != nil || (ctrlResult != ctrl.Result{}) {
 		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
-		return ctrlResult, nil
 	}
 
 	//
@@ -473,7 +465,8 @@ func (r *HeatReconciler) reconcileNormal(ctx context.Context, instance *heatv1be
 			heatv1beta1.HeatStackDomainReadyErrorMessage,
 			err.Error()))
 		return ctrl.Result{}, err
-	} else if (ctrlResult != ctrl.Result{}) {
+	}
+	if (ctrlResult != ctrl.Result{}) {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			heatv1beta1.HeatStackDomainReadyCondition,
 			condition.RequestedReason,
@@ -916,10 +909,8 @@ func (r *HeatReconciler) ensureStackDomain(
 		helper,
 		keystoneAPI,
 	)
-	if err != nil {
-		return ctrl.Result{}, err
-	} else if (ctrlResult != ctrl.Result{}) {
-		return ctrlResult, nil
+	if err != nil || (ctrlResult != ctrl.Result{}) {
+		return ctrlResult, err
 	}
 
 	// create domain

--- a/controllers/heatapi_controller.go
+++ b/controllers/heatapi_controller.go
@@ -303,7 +303,8 @@ func (r *HeatAPIReconciler) reconcileInit(
 			condition.ExposeServiceReadyErrorMessage,
 			err.Error()))
 		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
+	}
+	if (ctrlResult != ctrl.Result{}) {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.ExposeServiceReadyCondition,
 			condition.RequestedReason,
@@ -332,7 +333,7 @@ func (r *HeatAPIReconciler) reconcileInit(
 
 		ksSvcObj := keystonev1.NewKeystoneService(ksSvcSpec, instance.Namespace, serviceLabels, time.Duration(10)*time.Second)
 		ctrlResult, err = ksSvcObj.CreateOrPatch(ctx, helper)
-		if err != nil {
+		if err != nil || (ctrlResult != ctrl.Result{}) {
 			return ctrlResult, err
 		}
 
@@ -341,10 +342,6 @@ func (r *HeatAPIReconciler) reconcileInit(
 		c := ksSvcObj.GetConditions().Mirror(condition.KeystoneServiceReadyCondition)
 		if c != nil {
 			instance.Status.Conditions.Set(c)
-		}
-
-		if (ctrlResult != ctrl.Result{}) {
-			return ctrlResult, nil
 		}
 
 		//
@@ -361,7 +358,7 @@ func (r *HeatAPIReconciler) reconcileInit(
 			serviceLabels,
 			time.Duration(10)*time.Second)
 		ctrlResult, err = ksEndpt.CreateOrPatch(ctx, helper)
-		if err != nil {
+		if err != nil || (ctrlResult != ctrl.Result{}) {
 			return ctrlResult, err
 		}
 		// mirror the Status, Reason, Severity and Message of the latest keystoneendpoint condition
@@ -369,10 +366,6 @@ func (r *HeatAPIReconciler) reconcileInit(
 		c = ksEndpt.GetConditions().Mirror(condition.KeystoneEndpointReadyCondition)
 		if c != nil {
 			instance.Status.Conditions.Set(c)
-		}
-
-		if (ctrlResult != ctrl.Result{}) {
-			return ctrlResult, nil
 		}
 	}
 
@@ -510,26 +503,20 @@ func (r *HeatAPIReconciler) reconcileNormal(ctx context.Context, instance *heatv
 
 	// Handle service init
 	ctrlResult, err := r.reconcileInit(ctx, instance, helper, serviceLabels)
-	if err != nil {
+	if err != nil || (ctrlResult != ctrl.Result{}) {
 		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
-		return ctrlResult, nil
 	}
 
 	// Handle service update
 	ctrlResult, err = r.reconcileUpdate(ctx, instance, helper)
-	if err != nil {
+	if err != nil || (ctrlResult != ctrl.Result{}) {
 		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
-		return ctrlResult, nil
 	}
 
 	// Handle service upgrade
 	ctrlResult, err = r.reconcileUpgrade(ctx, instance, helper)
-	if err != nil {
+	if err != nil || (ctrlResult != ctrl.Result{}) {
 		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
-		return ctrlResult, nil
 	}
 
 	//
@@ -551,7 +538,8 @@ func (r *HeatAPIReconciler) reconcileNormal(ctx context.Context, instance *heatv
 			condition.DeploymentReadyErrorMessage,
 			err.Error()))
 		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
+	}
+	if (ctrlResult != ctrl.Result{}) {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.DeploymentReadyCondition,
 			condition.RequestedReason,

--- a/controllers/heatcfnapi_controller.go
+++ b/controllers/heatcfnapi_controller.go
@@ -307,7 +307,8 @@ func (r *HeatCfnAPIReconciler) reconcileInit(
 			condition.ExposeServiceReadyErrorMessage,
 			err.Error()))
 		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
+	}
+	if (ctrlResult != ctrl.Result{}) {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.ExposeServiceReadyCondition,
 			condition.RequestedReason,
@@ -336,7 +337,7 @@ func (r *HeatCfnAPIReconciler) reconcileInit(
 
 		ksSvcObj := keystonev1.NewKeystoneService(ksSvcSpec, instance.Namespace, serviceLabels, time.Duration(10)*time.Second)
 		ctrlResult, err = ksSvcObj.CreateOrPatch(ctx, helper)
-		if err != nil {
+		if err != nil || (ctrlResult != ctrl.Result{}) {
 			return ctrlResult, err
 		}
 
@@ -345,10 +346,6 @@ func (r *HeatCfnAPIReconciler) reconcileInit(
 		c := ksSvcObj.GetConditions().Mirror(condition.KeystoneServiceReadyCondition)
 		if c != nil {
 			instance.Status.Conditions.Set(c)
-		}
-
-		if (ctrlResult != ctrl.Result{}) {
-			return ctrlResult, nil
 		}
 
 		//
@@ -365,7 +362,7 @@ func (r *HeatCfnAPIReconciler) reconcileInit(
 			serviceLabels,
 			time.Duration(10)*time.Second)
 		ctrlResult, err = ksEndpt.CreateOrPatch(ctx, helper)
-		if err != nil {
+		if err != nil || (ctrlResult != ctrl.Result{}) {
 			return ctrlResult, err
 		}
 		// mirror the Status, Reason, Severity and Message of the latest keystoneendpoint condition
@@ -373,10 +370,6 @@ func (r *HeatCfnAPIReconciler) reconcileInit(
 		c = ksEndpt.GetConditions().Mirror(condition.KeystoneEndpointReadyCondition)
 		if c != nil {
 			instance.Status.Conditions.Set(c)
-		}
-
-		if (ctrlResult != ctrl.Result{}) {
-			return ctrlResult, nil
 		}
 	}
 
@@ -514,26 +507,20 @@ func (r *HeatCfnAPIReconciler) reconcileNormal(ctx context.Context, instance *he
 
 	// Handle service init
 	ctrlResult, err := r.reconcileInit(ctx, instance, helper, serviceLabels)
-	if err != nil {
+	if err != nil || (ctrlResult != ctrl.Result{}) {
 		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
-		return ctrlResult, nil
 	}
 
 	// Handle service update
 	ctrlResult, err = r.reconcileUpdate(ctx, instance, helper)
-	if err != nil {
+	if err != nil || (ctrlResult != ctrl.Result{}) {
 		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
-		return ctrlResult, nil
 	}
 
 	// Handle service upgrade
 	ctrlResult, err = r.reconcileUpgrade(ctx, instance, helper)
-	if err != nil {
+	if err != nil || (ctrlResult != ctrl.Result{}) {
 		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
-		return ctrlResult, nil
 	}
 
 	//
@@ -555,7 +542,8 @@ func (r *HeatCfnAPIReconciler) reconcileNormal(ctx context.Context, instance *he
 			condition.DeploymentReadyErrorMessage,
 			err.Error()))
 		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
+	}
+	if (ctrlResult != ctrl.Result{}) {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.DeploymentReadyCondition,
 			condition.RequestedReason,

--- a/controllers/heatengine_controller.go
+++ b/controllers/heatengine_controller.go
@@ -351,26 +351,20 @@ func (r *HeatEngineReconciler) reconcileNormal(
 
 	// Handle service init
 	ctrlResult, err := r.reconcileInit(ctx, instance, helper, serviceLabels)
-	if err != nil {
+	if err != nil || (ctrlResult != ctrl.Result{}) {
 		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
-		return ctrlResult, nil
 	}
 
 	// Handle service update
 	ctrlResult, err = r.reconcileUpdate(ctx, instance, helper)
-	if err != nil {
+	if err != nil || (ctrlResult != ctrl.Result{}) {
 		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
-		return ctrlResult, nil
 	}
 
 	// Handle service upgrade
 	ctrlResult, err = r.reconcileUpgrade(ctx, instance, helper)
-	if err != nil {
+	if err != nil || (ctrlResult != ctrl.Result{}) {
 		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
-		return ctrlResult, nil
 	}
 
 	depl := deployment.NewDeployment(
@@ -387,7 +381,8 @@ func (r *HeatEngineReconciler) reconcileNormal(
 			condition.DeploymentReadyErrorMessage,
 			err.Error()))
 		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
+	}
+	if (ctrlResult != ctrl.Result{}) {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.DeploymentReadyCondition,
 			condition.RequestedReason,


### PR DESCRIPTION
If we're returning from a if statement, we really don't need an else. These can be simplified and made more legible by simply removing the else and having a seperate if block.

This is really just a quality of life patch. IMO, the use of `else` can often make code a bit harder to follow and read. 

If this is just something we're doing for consistency with the wider org's sake, I'm happy to raise it to the wider group for broader perspective. But at least here, I think it makes things a little nicer to read and follow. 