### PR TITLE
Use consistent method for setting time.Second * n

### DIFF
--- a/controllers/heat_controller.go
+++ b/controllers/heat_controller.go
@@ -360,7 +360,7 @@ func (r *HeatReconciler) reconcileNormal(ctx context.Context, instance *heatv1be
 			condition.SeverityInfo,
 			condition.RabbitMqTransportURLReadyRunningMessage))
 
-		return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, nil
+		return ctrl.Result{RequeueAfter: time.Second * 10}, nil
 	}
 
 	//
@@ -375,7 +375,7 @@ func (r *HeatReconciler) reconcileNormal(ctx context.Context, instance *heatv1be
 				condition.RequestedReason,
 				condition.SeverityInfo,
 				condition.RabbitMqTransportURLReadyRunningMessage))
-			return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, fmt.Errorf("TransportURL secret %s not found", instance.Status.TransportURLSecret)
+			return ctrl.Result{RequeueAfter: time.Second * 10}, fmt.Errorf("TransportURL secret %s not found", instance.Status.TransportURLSecret)
 		}
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.RabbitMqTransportURLReadyCondition,
@@ -634,7 +634,7 @@ func (r *HeatReconciler) reconcileInit(ctx context.Context,
 		jobDef,
 		heatv1beta1.DbSyncHash,
 		instance.Spec.PreserveJobs,
-		time.Duration(5)*time.Second,
+		time.Second * 10,
 		dbSyncHash,
 	)
 	ctrlResult, err = dbSyncjob.DoJob(

--- a/controllers/heatapi_controller.go
+++ b/controllers/heatapi_controller.go
@@ -293,7 +293,7 @@ func (r *HeatAPIReconciler) reconcileInit(
 		heatapi.ServiceName,
 		serviceLabels,
 		data,
-		time.Duration(5)*time.Second,
+		time.Second * 5,
 	)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
@@ -330,7 +330,7 @@ func (r *HeatAPIReconciler) reconcileInit(
 			PasswordSelector:   instance.Spec.PasswordSelectors.Service,
 		}
 
-		ksSvcObj := keystonev1.NewKeystoneService(ksSvcSpec, instance.Namespace, serviceLabels, time.Duration(10)*time.Second)
+		ksSvcObj := keystonev1.NewKeystoneService(ksSvcSpec, instance.Namespace, serviceLabels, time.Second * 10)
 		ctrlResult, err = ksSvcObj.CreateOrPatch(ctx, helper)
 		if err != nil {
 			return ctrlResult, err
@@ -359,7 +359,7 @@ func (r *HeatAPIReconciler) reconcileInit(
 			instance.Namespace,
 			ksEndptSpec,
 			serviceLabels,
-			time.Duration(10)*time.Second)
+			time.Second * 10)
 		ctrlResult, err = ksEndpt.CreateOrPatch(ctx, helper)
 		if err != nil {
 			return ctrlResult, err
@@ -539,7 +539,7 @@ func (r *HeatAPIReconciler) reconcileNormal(ctx context.Context, instance *heatv
 	// Define a new Deployment object
 	depl := deployment.NewDeployment(
 		heatapi.Deployment(instance, inputHash, serviceLabels),
-		time.Duration(5)*time.Second,
+		time.Second * 5,
 	)
 
 	ctrlResult, err = depl.CreateOrPatch(ctx, helper)

--- a/controllers/heatcfnapi_controller.go
+++ b/controllers/heatcfnapi_controller.go
@@ -297,7 +297,7 @@ func (r *HeatCfnAPIReconciler) reconcileInit(
 		heatcfnapi.ServiceName,
 		serviceLabels,
 		data,
-		time.Duration(5)*time.Second,
+		time.Second * 5,
 	)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
@@ -334,7 +334,7 @@ func (r *HeatCfnAPIReconciler) reconcileInit(
 			PasswordSelector:   instance.Spec.PasswordSelectors.Service,
 		}
 
-		ksSvcObj := keystonev1.NewKeystoneService(ksSvcSpec, instance.Namespace, serviceLabels, time.Duration(10)*time.Second)
+		ksSvcObj := keystonev1.NewKeystoneService(ksSvcSpec, instance.Namespace, serviceLabels, time.Second * 10)
 		ctrlResult, err = ksSvcObj.CreateOrPatch(ctx, helper)
 		if err != nil {
 			return ctrlResult, err
@@ -363,7 +363,7 @@ func (r *HeatCfnAPIReconciler) reconcileInit(
 			instance.Namespace,
 			ksEndptSpec,
 			serviceLabels,
-			time.Duration(10)*time.Second)
+			time.Second * 10)
 		ctrlResult, err = ksEndpt.CreateOrPatch(ctx, helper)
 		if err != nil {
 			return ctrlResult, err
@@ -543,7 +543,7 @@ func (r *HeatCfnAPIReconciler) reconcileNormal(ctx context.Context, instance *he
 	// Define a new Deployment object
 	depl := deployment.NewDeployment(
 		heatcfnapi.Deployment(instance, inputHash, serviceLabels),
-		time.Duration(5)*time.Second,
+		time.Second * 10,
 	)
 
 	ctrlResult, err = depl.CreateOrPatch(ctx, helper)

--- a/controllers/heatengine_controller.go
+++ b/controllers/heatengine_controller.go
@@ -375,7 +375,7 @@ func (r *HeatEngineReconciler) reconcileNormal(
 
 	depl := deployment.NewDeployment(
 		heatengine.Deployment(instance, inputHash, serviceLabels),
-		time.Duration(5)*time.Second,
+		time.Second * 5,
 	)
 
 	ctrlResult, err = depl.CreateOrPatch(ctx, helper)


### PR DESCRIPTION
Currently, we still have a mix of time.Duration and time.Second. This change replaces the remaining time.Duration instances with time.Second * n.