### PR TITLE
Remove unnecessary DocumentRoot for apache

### DIFF
--- a/pkg/heatapi/deployment.go
+++ b/pkg/heatapi/deployment.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	// ServiceCommand -
-	ServiceCommand = "/usr/local/bin/container-scripts/api-prep.sh && /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start"
+	ServiceCommand = "/usr/local/bin/kolla_httpd_setup && /usr/local/bin/kolla_start"
 )
 
 // Deployment func

--- a/pkg/heatcfnapi/deployment.go
+++ b/pkg/heatcfnapi/deployment.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	// ServiceCommand -
-	ServiceCommand = "/usr/local/bin/container-scripts/api-prep.sh && /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start"
+	ServiceCommand = "/usr/local/bin/kolla_httpd_setup && /usr/local/bin/kolla_start"
 )
 
 // Deployment func

--- a/pkg/heatengine/deployment.go
+++ b/pkg/heatengine/deployment.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	// ServiceCommand -
-	ServiceCommand = "/usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start"
+	ServiceCommand = "/usr/local/bin/kolla_start"
 )
 
 // Deployment func

--- a/templates/heat/config/heat-api-httpd.conf
+++ b/templates/heat/config/heat-api-httpd.conf
@@ -21,18 +21,7 @@ CustomLog /dev/stdout proxy env=forwarded
 <VirtualHost *:8004>
   ServerName heat-api
 
-  ## Vhost docroot
-  DocumentRoot "/var/www/cgi-bin/heat"
-
   AllowEncodedSlashes on
-
-  ## Directories, there should at least be a declaration for /var/www/cgi-bin/heat
-
-  <Directory "/var/www/cgi-bin/heat">
-    Options -Indexes +FollowSymLinks +MultiViews
-    AllowOverride None
-    Require all granted
-  </Directory>
 
   ## Logging
   LogLevel debug

--- a/templates/heat/config/heat-cfnapi-httpd.conf
+++ b/templates/heat/config/heat-cfnapi-httpd.conf
@@ -21,18 +21,7 @@ CustomLog /dev/stdout proxy env=forwarded
 <VirtualHost *:8000>
   ServerName heat-api-cfn
 
-  ## Vhost docroot
-  DocumentRoot "/var/www/cgi-bin/heat"
-
   AllowEncodedSlashes on
-
-  ## Directories, there should at least be a declaration for /var/www/cgi-bin/heat
-
-  <Directory "/var/www/cgi-bin/heat">
-    Options -Indexes +FollowSymLinks +MultiViews
-    AllowOverride None
-    Require all granted
-  </Directory>
 
   ## Logging
   LogLevel debug


### PR DESCRIPTION
This option is not really used because we have WsgiScriptAlias which directs access under / to the script.