### PR TITLE
Support disconnected network environments

### DIFF
--- a/.github/create_bundle.sh
+++ b/.github/create_bundle.sh
@@ -1,69 +1,13 @@
 #!/bin/bash
 set -e
 
-CLUSTER_BUNDLE_FILE="bundle/manifests/heat-operator.clusterserviceversion.yaml"
-
 echo "Creating heat operator bundle"
 cd ..
 echo "${GITHUB_SHA}"
 echo "${BASE_IMAGE}"
-skopeo --version
-
-echo "Calculating image digest for docker://${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA}"
-DIGEST=$(skopeo inspect docker://${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA} | jq '.Digest' -r)
-# Output:
-# Calculating image digest for docker://quay.io/openstack-k8s-operators/heat-operator:d03f2c1c362c04fc5ef819f92a218f9ea59bbd0c
-# Digest: sha256:1d5b578fd212f8dbd03c0235f1913ef738721766f8c94236af5efecc6d8d8cb1
-echo "Digest: ${DIGEST}"
 
 RELEASE_VERSION=$(grep "^VERSION" Makefile | awk -F'?= ' '{ print $2 }')
-OPERATOR_IMG_WITH_DIGEST="${REGISTRY}/${BASE_IMAGE}@${DIGEST}"
-
-echo "New Operator Image with Digest: $OPERATOR_IMG_WITH_DIGEST"
 echo "Release Version: $RELEASE_VERSION"
 
 echo "Creating bundle image..."
-VERSION=$RELEASE_VERSION IMG=$OPERATOR_IMG_WITH_DIGEST make bundle
-
-echo "Bundle file images:"
-cat "${CLUSTER_BUNDLE_FILE}" | grep "image:"
-# FIXME: display any ENV variables once we have offline support implemented
-#grep -A1 IMAGE_URL_DEFAULT "${CLUSTER_BUNDLE_FILE}"
-
-# We do not want to exit here. Some images are in different registries, so
-# error will be reported to the console.
-set +e
-for csv_image in $(cat "${CLUSTER_BUNDLE_FILE}" | grep "image:" | sed -e "s|.*image:||" | sort -u); do
-    digest_image=""
-    echo "CSV line: ${csv_image}"
-
-    # case where @ is in the csv_image image
-    if [[ "$csv_image" =~ .*"@".* ]]; then
-        delimeter='@'
-    else
-        delimeter=':'
-    fi
-
-    base_image=$(echo $csv_image | cut -f 1 -d${delimeter})
-    tag_image=$(echo $csv_image | cut -f 2 -d${delimeter})
-
-    if [[ "$base_image:$tag_image" == "controller:latest" ]]; then
-        echo "$base_image:$tag_image becomes $OPERATOR_IMG_WITH_DIGEST"
-        sed -e "s|$base_image:$tag_image|$OPERATOR_IMG_WITH_DIGEST|g" -i "${CLUSTER_BUNDLE_FILE}"
-    else
-        digest_image=$(skopeo inspect docker://${base_image}${delimeter}${tag_image} | jq '.Digest' -r)
-        echo "Base image: $base_image"
-        if [ -n "$digest_image" ]; then
-            echo "$base_image${delimeter}$tag_image becomes $base_image@$digest_image"
-            sed -i "s|$base_image$delimeter$tag_image|$base_image@$digest_image|g" "${CLUSTER_BUNDLE_FILE}"
-        else
-            echo "$base_image${delimeter}$tag_image not changed"
-        fi
-    fi
-done
-
-echo "Resulting bundle file images:"
-cat "${CLUSTER_BUNDLE_FILE}" | grep "image:"
-
-# FIXME: display any ENV variables once we have offline support implemented
-#grep -A1 IMAGE_URL_DEFAULT "${CLUSTER_BUNDLE_FILE}"
+USE_IMAGE_DIGESTS=true VERSION=$RELEASE_VERSION IMG=${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA} make bundle

--- a/api/v1beta1/heat_types.go
+++ b/api/v1beta1/heat_types.go
@@ -169,9 +169,9 @@ func (instance Heat) RbacResourceName() string {
 func SetupDefaults() {
 	// Acquire environmental defaults and initialize Heat defaults with them
 	heatDefaults := HeatDefaults{
-		APIContainerImageURL:    util.GetEnvVar("HEAT_API_IMAGE_URL_DEFAULT", HeatAPIContainerImage),
-		CfnAPIContainerImageURL: util.GetEnvVar("HEAT_CFNAPI_IMAGE_URL_DEFAULT", HeatCfnAPIContainerImage),
-		EngineContainerImageURL: util.GetEnvVar("HEAT_ENGINE_IMAGE_URL_DEFAULT", HeatEngineContainerImage),
+		APIContainerImageURL:    util.GetEnvVar("RELATED_IMAGE_HEAT_API_IMAGE_URL_DEFAULT", HeatAPIContainerImage),
+		CfnAPIContainerImageURL: util.GetEnvVar("RELATED_IMAGE_HEAT_CFNAPI_IMAGE_URL_DEFAULT", HeatCfnAPIContainerImage),
+		EngineContainerImageURL: util.GetEnvVar("RELATED_IMAGE_HEAT_ENGINE_IMAGE_URL_DEFAULT", HeatEngineContainerImage),
 	}
 
 	SetupHeatDefaults(heatDefaults)

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -11,9 +11,9 @@ spec:
       containers:
       - name: manager
         env:
-        - name: HEAT_API_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_HEAT_API_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-heat-api:current-podified
-        - name: HEAT_CFNAPI_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_HEAT_CFNAPI_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-heat-api-cfn:current-podified
-        - name: HEAT_ENGINE_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_HEAT_ENGINE_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-heat-engine:current-podified

--- a/config/manifests/bases/heat-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/heat-operator.clusterserviceversion.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/operator-type: non-standalone
   name: heat-operator.v0.0.1
   namespace: openstack

--- a/tests/kuttl/common/assert-sample-deployment.yaml
+++ b/tests/kuttl/common/assert-sample-deployment.yaml
@@ -196,3 +196,35 @@ commands:
           echo "${PUBLIC_URL} status code expected is 204 but was ${STATUSCODE}"
       fi
       exit $RETURN_CODE
+---
+#
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+  - script: |
+      tupleTemplate='{{ range (index .spec.template.spec.containers 1).env }}{{ .name }}{{ "#" }}{{ .value}}{{"\n"}}{{ end }}'
+      imageTuples=$(oc get -n openstack-operators deployment heat-operator-controller-manager -o go-template="$tupleTemplate")
+      for ITEM in $(echo $imageTuples); do
+        # it is an image
+        if echo $ITEM | grep 'RELATED_IMAGE' &> /dev/null; then
+          NAME=$(echo $ITEM | sed -e 's|^RELATED_IMAGE_HEAT_\([^_]*\)_.*|\1|')
+          IMG_FROM_ENV=$(echo $ITEM | sed -e 's|^.*#\(.*\)|\1|')
+          template='{{.spec.containerImage}}'
+          case $NAME in
+            API)
+              SERVICE_IMAGE=$(oc get -n $NAMESPACE heatapi heat-api -o go-template="$template")
+              ;;
+            CFNAPI)
+              SERVICE_IMAGE=$(oc get -n $NAMESPACE heatcfnapi heat-cfnapi -o go-template="$template")
+              ;;
+            ENGINE)
+              SERVICE_IMAGE=$(oc get -n $NAMESPACE heatengine heat-engine -o go-template="$template")
+              ;;
+          esac
+          if [ "$SERVICE_IMAGE" != "$IMG_FROM_ENV" ]; then
+            echo "$NAME image ($SERVICE_IMAGE) does not equal $IMG_FROM_ENV"
+            exit 1
+          fi
+        fi
+      done
+      exit 0


### PR DESCRIPTION
This PR adds support for installing the operator in disconnected network environments. To build with image-digests set USE_IMAGE_DIGESTS=true before running make bundle.

For Prow jobs we are enabling this via .prow-ci.env

This drops the old logic from create_bundle.sh which has been broken with operator-sdk's make bundle for some time.

(NOTE: this currently requires a secure registry)

Jira: [OSP-26486](https://issues.redhat.com//browse/OSP-26486)