### PR TITLE
Revert "Remove Takashi from OWNERS_ALIASES file"

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -3,6 +3,7 @@
 aliases:
   heat-approvers:
   - bshephar
+  - kajinamit
   - rabi
   ci-approvers:
   - Sandeepyadav93


### PR DESCRIPTION
Reverts openstack-k8s-operators/heat-operator#242

I would rather not forcefully remove folks from this public community project. Particularly members that have been instrumental to the existence of the project. At least from the Heat and Horizon operator perspective, this change will be reverted to allow members to choose their level of participation.

They can elect to remove themselves if that is their desire.