### PR TITLE
Bypass validate update

### DIFF
--- a/api/v1beta1/heat_types.go
+++ b/api/v1beta1/heat_types.go
@@ -36,6 +36,8 @@ const (
 	HeatCfnAPIContainerImage = "quay.io/podified-antelope-centos9/openstack-heat-api-cfn:current-podified"
 	// HeatEngineContainerImage - default fall-back container image for HeatEngine if associated env var not provided
 	HeatEngineContainerImage = "quay.io/podified-antelope-centos9/openstack-heat-engine:current-podified"
+	// HeatDatabaseMigrationAnnotation - Allows users to bypass the webhook validations for changes to databaseInstance
+	HeatDatabaseMigrationAnnotation = "heat.openstack.org/database-migration"
 )
 
 // HeatSpec defines the desired state of Heat


### PR DESCRIPTION
This change allows for the ValidateUpdate() webhook to be bypassed. This provides functionality for advanced use cases where the user has independently validated that their update won't break the deployment, or orphan any data in an old database.

It's anticipated that this functionality will be required in cases where we deploy the control plane and point it at an existing database. Then perform a database migration, in which case we want to redirect the Heat deployment to the new database.

Since this operation is inherently dangerous. By default, this is an undocumented feature that is intended to facilitate situations where users are confident in the operation they are performing.