### PR TITLE
Use internal Keystone endpoint

### DIFF
--- a/controllers/heat_controller.go
+++ b/controllers/heat_controller.go
@@ -871,13 +871,13 @@ func (r *HeatReconciler) generateServiceConfigMaps(
 		return err
 	}
 
-	authURL, err := keystoneAPI.GetEndpoint(endpoint.EndpointPublic)
+	authURL, err := keystoneAPI.GetEndpoint(endpoint.EndpointInternal)
 	if err != nil {
 		return err
 	}
 
 	templateParameters := map[string]interface{}{
-		"KeystonePublicURL":        authURL,
+		"KeystoneInternalURL":      authURL,
 		"ServiceUser":              instance.Spec.ServiceUser,
 		"StackDomainAdminUsername": heat.StackDomainAdminUsername,
 		"StackDomainName":          heat.StackDomainName,

--- a/templates/heat/config/heat.conf
+++ b/templates/heat/config/heat.conf
@@ -18,7 +18,7 @@ max_retries=-1
 db_max_retries=-1
 
 [ec2authtoken]
-auth_uri={{ .KeystonePublicURL }}/v3/ec2tokens
+auth_uri={{ .KeystoneInternalURL }}/v3/ec2tokens
 
 [oslo_messaging_notifications]
 driver=noop
@@ -28,7 +28,7 @@ enable_proxy_headers_parsing=True
 
 [trustee]
 auth_type=password
-auth_url={{ .KeystonePublicURL }}
+auth_url={{ .KeystoneInternalURL }}
 username=heat
 user_domain_name=Default
 #password =
@@ -37,12 +37,12 @@ user_domain_name=Default
 caching=False
 
 [keystone_authtoken]
-www_authenticate_uri={{ .KeystonePublicURL }}
+www_authenticate_uri={{ .KeystoneInternalURL }}
 auth_type=password
 memcache_use_advanced_pool=True
 memcached_servers={{ .MemcachedServersWithInet }}
 region_name=regionOne
-auth_url={{ .KeystonePublicURL }}
+auth_url={{ .KeystoneInternalURL }}
 username={{ .ServiceUser }}
 user_domain_name=Default
 #password =

--- a/tests/functional/heat_controller_test.go
+++ b/tests/functional/heat_controller_test.go
@@ -306,11 +306,11 @@ var _ = Describe("Heat controller", func() {
 			Expect(cm.Data["heat.conf"]).Should(
 				ContainSubstring("stack_domain_admin=heat_stack_domain_admin"))
 			Expect(cm.Data["heat.conf"]).Should(
-				ContainSubstring("auth_uri=%s/v3/ec2tokens", keystoneAPI.Status.APIEndpoints["public"]))
+				ContainSubstring("auth_uri=%s/v3/ec2tokens", keystoneAPI.Status.APIEndpoints["internal"]))
 			Expect(cm.Data["heat.conf"]).Should(
-				ContainSubstring("auth_url=%s", keystoneAPI.Status.APIEndpoints["public"]))
+				ContainSubstring("auth_url=%s", keystoneAPI.Status.APIEndpoints["internal"]))
 			Expect(cm.Data["heat.conf"]).Should(
-				ContainSubstring("www_authenticate_uri=http://keystone-public-openstack.testing"))
+				ContainSubstring("www_authenticate_uri=http://keystone-internal.openstack.svc"))
 			Expect(cm.Data["heat.conf"]).Should(
 				ContainSubstring("memcache_servers=memcached-0.memcached:11211,memcached-1.memcached:11211,memcached-2.memcached:11211"))
 			Expect(cm.Data["heat.conf"]).Should(


### PR DESCRIPTION
This change updates the heat.conf file to ensure our connections to Keystone happen via the internal endpoint rather than the public one.