### PR TITLE
Fix bundle validations

### DIFF
--- a/config/samples/heat_v1beta1_heatapi.yaml
+++ b/config/samples/heat_v1beta1_heatapi.yaml
@@ -1,0 +1,19 @@
+apiVersion: heat.openstack.org/v1beta1
+kind: HeatAPI
+metadata:
+  name: heat-api
+spec:
+  databaseHostname: openstack
+  databaseUser: heat
+  debug:
+    service: false
+  passwordSelectors:
+    authEncryptionKey: HeatAuthEncryptionKey
+    database: HeatDatabasePassword
+    service: HeatPassword
+  replicas: 1
+  resources: {}
+  secret: osp-secret
+  serviceAccount: heat-heat
+  serviceUser: heat
+  transportURLSecret: rabbitmq-transport-url-heat-heat-transport

--- a/config/samples/heat_v1beta1_heatapicfn.yaml
+++ b/config/samples/heat_v1beta1_heatapicfn.yaml
@@ -1,0 +1,19 @@
+apiVersion: heat.openstack.org/v1beta1
+kind: HeatCfnAPI
+metadata:
+  name: heat-cfnapi
+spec:
+  databaseHostname: openstack
+  databaseUser: heat
+  debug:
+    service: false
+  passwordSelectors:
+    authEncryptionKey: HeatAuthEncryptionKey
+    database: HeatDatabasePassword
+    service: HeatPassword
+  replicas: 1
+  resources: {}
+  secret: osp-secret
+  serviceAccount: heat-heat
+  serviceUser: heat
+  transportURLSecret: rabbitmq-transport-url-heat-heat-transport

--- a/config/samples/heat_v1beta1_heatengine.yaml
+++ b/config/samples/heat_v1beta1_heatengine.yaml
@@ -1,0 +1,19 @@
+apiVersion: heat.openstack.org/v1beta1
+kind: HeatEngine
+metadata:
+  name: heat-engine
+spec:
+  databaseHostname: openstack
+  databaseUser: heat
+  debug:
+    service: false
+  passwordSelectors:
+    authEncryptionKey: HeatAuthEncryptionKey
+    database: HeatDatabasePassword
+    service: HeatPassword
+  replicas: 1
+  resources: {}
+  secret: osp-secret
+  serviceAccount: heat-heat
+  serviceUser: heat
+  transportURLSecret: rabbitmq-transport-url-heat-heat-transport

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,4 +1,7 @@
 ## Append samples you want in your CSV to this file as resources ##
 resources:
 - heat_v1beta1_heat.yaml
+- heat_v1beta1_heatapi.yaml
+- heat_v1beta1_heatapicfn.yaml
+- heat_v1beta1_heatengine.yaml
 #+kubebuilder:scaffold:manifestskustomizesamples


### PR DESCRIPTION
Fixes the following bundle validation warnings by adding samples of these internal APIs:

WARN[0000] Warning: Value heat.openstack.org/v1beta1, Kind=HeatAPI: provided API should have an example annotation
WARN[0000] Warning: Value heat.openstack.org/v1beta1, Kind=HeatCfnAPI: provided API should have an example annotation
WARN[0000] Warning: Value heat.openstack.org/v1beta1, Kind=HeatEngine: provided API should have an example annotation