### PR TITLE
Use APIDetails as object for initContainer method

### DIFF
--- a/pkg/heat/dbsync.go
+++ b/pkg/heat/dbsync.go
@@ -81,7 +81,7 @@ func DBSyncJob(
 
 	job.Spec.Template.Spec.Volumes = GetVolumes(ServiceName)
 
-	initContainerDetails := APIDetails{
+	initAPIDetails := APIDetails{
 		ContainerImage:            instance.Spec.HeatAPI.ContainerImage,
 		DatabaseHost:              instance.Status.DatabaseHostname,
 		DatabaseUser:              instance.Spec.DatabaseUser,
@@ -92,7 +92,7 @@ func DBSyncJob(
 		AuthEncryptionKeySelector: instance.Spec.PasswordSelectors.AuthEncryptionKey,
 		VolumeMounts:              GetInitVolumeMounts(),
 	}
-	job.Spec.Template.Spec.InitContainers = InitContainer(initContainerDetails)
+	job.Spec.Template.Spec.InitContainers = initAPIDetails.InitContainer()
 
 	return job
 }

--- a/pkg/heat/initcontainer.go
+++ b/pkg/heat/initcontainer.go
@@ -38,11 +38,11 @@ type APIDetails struct {
 
 // InitContainerCommand is
 const (
-	InitContainerCommand = "/usr/local/bin/container-scripts/init.sh"
+	InitContainerCommand = "/usr/local/bin/container-scripts/a.sh"
 )
 
 // InitContainer ..
-func InitContainer(init APIDetails) []corev1.Container {
+func (a *APIDetails) InitContainer() []corev1.Container {
 	runAsUser := int64(0)
 	trueVar := true
 
@@ -50,14 +50,14 @@ func InitContainer(init APIDetails) []corev1.Container {
 		RunAsUser: &runAsUser,
 	}
 
-	if init.Privileged {
+	if a.Privileged {
 		securityContext.Privileged = &trueVar
 	}
 
 	envVars := map[string]env.Setter{}
-	envVars["DatabaseHost"] = env.SetValue(init.DatabaseHost)
-	envVars["DatabaseUser"] = env.SetValue(init.DatabaseUser)
-	envVars["DatabaseName"] = env.SetValue(init.DatabaseName)
+	envVars["DatabaseHost"] = env.SetValue(a.DatabaseHost)
+	envVars["DatabaseUser"] = env.SetValue(a.DatabaseUser)
+	envVars["DatabaseName"] = env.SetValue(a.DatabaseName)
 
 	envs := []corev1.EnvVar{
 		{
@@ -65,9 +65,9 @@ func InitContainer(init APIDetails) []corev1.Container {
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: init.OSPSecret,
+						Name: a.OSPSecret,
 					},
-					Key: init.DBPasswordSelector,
+					Key: a.DBPasswordSelector,
 				},
 			},
 		},
@@ -76,9 +76,9 @@ func InitContainer(init APIDetails) []corev1.Container {
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: init.OSPSecret,
+						Name: a.OSPSecret,
 					},
-					Key: init.UserPasswordSelector,
+					Key: a.UserPasswordSelector,
 				},
 			},
 		},
@@ -87,22 +87,22 @@ func InitContainer(init APIDetails) []corev1.Container {
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: init.OSPSecret,
+						Name: a.OSPSecret,
 					},
-					Key: init.AuthEncryptionKeySelector,
+					Key: a.AuthEncryptionKeySelector,
 				},
 			},
 		},
 	}
 	envs = env.MergeEnvs(envs, envVars)
 
-	if init.TransportURL != "" {
+	if a.TransportURL != "" {
 		envTransport := corev1.EnvVar{
 			Name: "TransportURL",
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: init.TransportURL,
+						Name: a.TransportURL,
 					},
 					Key: "transport_url",
 				},
@@ -114,7 +114,7 @@ func InitContainer(init APIDetails) []corev1.Container {
 	return []corev1.Container{
 		{
 			Name:            "init",
-			Image:           init.ContainerImage,
+			Image:           a.ContainerImage,
 			SecurityContext: securityContext,
 			Command: []string{
 				"/bin/bash",
@@ -123,7 +123,7 @@ func InitContainer(init APIDetails) []corev1.Container {
 				InitContainerCommand,
 			},
 			Env:          envs,
-			VolumeMounts: init.VolumeMounts,
+			VolumeMounts: a.VolumeMounts,
 		},
 	}
 }

--- a/pkg/heatapi/deployment.go
+++ b/pkg/heatapi/deployment.go
@@ -143,7 +143,7 @@ func Deployment(
 		deployment.Spec.Template.Spec.NodeSelector = instance.Spec.NodeSelector
 	}
 
-	initContainerDetails := heat.APIDetails{
+	initAPIDetails := heat.APIDetails{
 		ContainerImage:            instance.Spec.ContainerImage,
 		DatabaseHost:              instance.Spec.DatabaseHostname,
 		DatabaseUser:              instance.Spec.DatabaseUser,
@@ -155,7 +155,7 @@ func Deployment(
 		VolumeMounts:              getInitVolumeMounts(),
 		TransportURL:              instance.Spec.TransportURLSecret,
 	}
-	deployment.Spec.Template.Spec.InitContainers = heat.InitContainer(initContainerDetails)
+	deployment.Spec.Template.Spec.InitContainers = initAPIDetails.InitContainer()
 
 	return deployment
 }

--- a/pkg/heatcfnapi/deployment.go
+++ b/pkg/heatcfnapi/deployment.go
@@ -143,7 +143,7 @@ func Deployment(
 		deployment.Spec.Template.Spec.NodeSelector = instance.Spec.NodeSelector
 	}
 
-	initContainerDetails := heat.APIDetails{
+	initAPIDetails := heat.APIDetails{
 		ContainerImage:            instance.Spec.ContainerImage,
 		DatabaseHost:              instance.Spec.DatabaseHostname,
 		DatabaseUser:              instance.Spec.DatabaseUser,
@@ -155,7 +155,7 @@ func Deployment(
 		VolumeMounts:              getInitVolumeMounts(),
 		TransportURL:              instance.Spec.TransportURLSecret,
 	}
-	deployment.Spec.Template.Spec.InitContainers = heat.InitContainer(initContainerDetails)
+	deployment.Spec.Template.Spec.InitContainers = initAPIDetails.InitContainer()
 
 	return deployment
 }

--- a/pkg/heatengine/deployment.go
+++ b/pkg/heatengine/deployment.go
@@ -140,7 +140,7 @@ func Deployment(instance *heatv1beta1.HeatEngine, configHash string, labels map[
 		deployment.Spec.Template.Spec.NodeSelector = instance.Spec.NodeSelector
 	}
 
-	initContainerDetails := heat.APIDetails{
+	initAPIDetails := heat.APIDetails{
 		ContainerImage:            instance.Spec.ContainerImage,
 		DatabaseHost:              instance.Spec.DatabaseHostname,
 		DatabaseUser:              instance.Spec.DatabaseUser,
@@ -152,7 +152,7 @@ func Deployment(instance *heatv1beta1.HeatEngine, configHash string, labels map[
 		VolumeMounts:              getInitVolumeMounts(),
 		TransportURL:              instance.Spec.TransportURLSecret,
 	}
-	deployment.Spec.Template.Spec.InitContainers = heat.InitContainer(initContainerDetails)
+	deployment.Spec.Template.Spec.InitContainers = initAPIDetails.InitContainer()
 
 	return deployment
 }


### PR DESCRIPTION
Currently, we pass the APIDetails struct to the InitContainer function. It seems a better design for this; since it is only relevant for the init container would be to have the InitContainer function be a method of the APIDetails object.