### PR TITLE
migrate from databaseUsername to databaseAccount and fully use MariaDBAccount

### DIFF
--- a/api/bases/heat.openstack.org_heatapis.yaml
+++ b/api/bases/heat.openstack.org_heatapis.yaml
@@ -54,14 +54,13 @@ spec:
                   added to to /etc/<service>/<service>.conf.d directory as custom.conf
                   file.
                 type: string
+              databaseAccount:
+                default: heat
+                description: DatabaseAccount - optional MariaDBAccount used for heat
+                  DB, defaults to heat.
+                type: string
               databaseHostname:
                 description: DatabaseHostname - Heat Database Hostname
-                type: string
-              databaseUser:
-                default: heat
-                description: 'DatabaseUser - optional username used for heat DB, defaults
-                  to heat. TODO: -> implement needs work in mariadb-operator, right
-                  now only heat.'
                 type: string
               defaultConfigOverwrite:
                 additionalProperties:
@@ -254,7 +253,6 @@ spec:
               passwordSelectors:
                 default:
                   authEncryptionKey: HeatAuthEncryptionKey
-                  database: HeatDatabasePassword
                   service: HeatPassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
@@ -263,11 +261,6 @@ spec:
                     default: HeatAuthEncryptionKey
                     description: AuthEncryptionKey - Selector to get the heat auth
                       encryption key from the Secret
-                    type: string
-                  database:
-                    default: HeatDatabasePassword
-                    description: 'Database - Selector to get the heat Database user
-                      password from the Secret TODO: not used, need change in mariadb-operator'
                     type: string
                   service:
                     default: HeatPassword

--- a/api/bases/heat.openstack.org_heatcfnapis.yaml
+++ b/api/bases/heat.openstack.org_heatcfnapis.yaml
@@ -54,14 +54,13 @@ spec:
                   added to to /etc/<service>/<service>.conf.d directory as custom.conf
                   file.
                 type: string
+              databaseAccount:
+                default: heat
+                description: DatabaseAccount - optional MariaDBAccount used for heat
+                  DB, defaults to heat.
+                type: string
               databaseHostname:
                 description: DatabaseHostname - Heat Database Hostname
-                type: string
-              databaseUser:
-                default: heat
-                description: 'DatabaseUser - optional username used for heat DB, defaults
-                  to heat. TODO: -> implement needs work in mariadb-operator, right
-                  now only heat.'
                 type: string
               defaultConfigOverwrite:
                 additionalProperties:
@@ -254,7 +253,6 @@ spec:
               passwordSelectors:
                 default:
                   authEncryptionKey: HeatAuthEncryptionKey
-                  database: HeatDatabasePassword
                   service: HeatPassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
@@ -263,11 +261,6 @@ spec:
                     default: HeatAuthEncryptionKey
                     description: AuthEncryptionKey - Selector to get the heat auth
                       encryption key from the Secret
-                    type: string
-                  database:
-                    default: HeatDatabasePassword
-                    description: 'Database - Selector to get the heat Database user
-                      password from the Secret TODO: not used, need change in mariadb-operator'
                     type: string
                   service:
                     default: HeatPassword

--- a/api/bases/heat.openstack.org_heatengines.yaml
+++ b/api/bases/heat.openstack.org_heatengines.yaml
@@ -54,14 +54,13 @@ spec:
                   added to to /etc/<service>/<service>.conf.d directory as custom.conf
                   file.
                 type: string
+              databaseAccount:
+                default: heat
+                description: DatabaseAccount - optional MariaDBAccount used for heat
+                  DB, defaults to heat.
+                type: string
               databaseHostname:
                 description: DatabaseHostname - Heat Database Hostname
-                type: string
-              databaseUser:
-                default: heat
-                description: 'DatabaseUser - optional username used for heat DB, defaults
-                  to heat. TODO: -> implement needs work in mariadb-operator, right
-                  now only heat.'
                 type: string
               defaultConfigOverwrite:
                 additionalProperties:
@@ -80,7 +79,6 @@ spec:
               passwordSelectors:
                 default:
                   authEncryptionKey: HeatAuthEncryptionKey
-                  database: HeatDatabasePassword
                   service: HeatPassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
@@ -89,11 +87,6 @@ spec:
                     default: HeatAuthEncryptionKey
                     description: AuthEncryptionKey - Selector to get the heat auth
                       encryption key from the Secret
-                    type: string
-                  database:
-                    default: HeatDatabasePassword
-                    description: 'Database - Selector to get the heat Database user
-                      password from the Secret TODO: not used, need change in mariadb-operator'
                     type: string
                   service:
                     default: HeatPassword

--- a/api/bases/heat.openstack.org_heats.yaml
+++ b/api/bases/heat.openstack.org_heats.yaml
@@ -51,16 +51,15 @@ spec:
                   added to to /etc/<service>/<service>.conf.d directory as custom.conf
                   file.
                 type: string
+              databaseAccount:
+                default: heat
+                description: DatabaseAccount - optional MariaDBAccount used for heat
+                  DB, defaults to heat.
+                type: string
               databaseInstance:
                 description: MariaDB instance name. Right now required by the maridb-operator
                   to get the credentials from the instance to create the DB. Might
                   not be required in future.
-                type: string
-              databaseUser:
-                default: heat
-                description: 'DatabaseUser - optional username used for heat DB, defaults
-                  to heat. TODO: -> implement needs work in mariadb-operator, right
-                  now only heat.'
                 type: string
               defaultConfigOverwrite:
                 additionalProperties:
@@ -771,7 +770,6 @@ spec:
               passwordSelectors:
                 default:
                   authEncryptionKey: HeatAuthEncryptionKey
-                  database: HeatDatabasePassword
                   service: HeatPassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
@@ -780,11 +778,6 @@ spec:
                     default: HeatAuthEncryptionKey
                     description: AuthEncryptionKey - Selector to get the heat auth
                       encryption key from the Secret
-                    type: string
-                  database:
-                    default: HeatDatabasePassword
-                    description: 'Database - Selector to get the heat Database user
-                      password from the Secret TODO: not used, need change in mariadb-operator'
                     type: string
                   service:
                     default: HeatPassword

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -30,9 +30,8 @@ type HeatTemplate struct {
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=heat
-	// DatabaseUser - optional username used for heat DB, defaults to heat.
-	// TODO: -> implement needs work in mariadb-operator, right now only heat.
-	DatabaseUser string `json:"databaseUser"`
+	// DatabaseAccount - optional MariaDBAccount used for heat DB, defaults to heat.
+	DatabaseAccount string `json:"databaseAccount"`
 
 	// +kubebuilder:validation:Required
 	// Secret containing OpenStack password information for heat HeatDatabasePassword, HeatPassword
@@ -40,7 +39,7 @@ type HeatTemplate struct {
 	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={database: HeatDatabasePassword, service: HeatPassword, authEncryptionKey: HeatAuthEncryptionKey}
+	// +kubebuilder:default={service: HeatPassword, authEncryptionKey: HeatAuthEncryptionKey}
 	// PasswordSelectors - Selectors to identify the DB and ServiceUser password from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors"`
 }
@@ -86,11 +85,6 @@ type APIOverrideSpec struct {
 
 // PasswordSelector ..
 type PasswordSelector struct {
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="HeatDatabasePassword"
-	// Database - Selector to get the heat Database user password from the Secret
-	// TODO: not used, need change in mariadb-operator
-	Database string `json:"database"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="HeatPassword"
 	// Service - Selector to get the heat service password from the Secret

--- a/config/crd/bases/heat.openstack.org_heatapis.yaml
+++ b/config/crd/bases/heat.openstack.org_heatapis.yaml
@@ -54,14 +54,13 @@ spec:
                   added to to /etc/<service>/<service>.conf.d directory as custom.conf
                   file.
                 type: string
+              databaseAccount:
+                default: heat
+                description: DatabaseAccount - optional MariaDBAccount used for heat
+                  DB, defaults to heat.
+                type: string
               databaseHostname:
                 description: DatabaseHostname - Heat Database Hostname
-                type: string
-              databaseUser:
-                default: heat
-                description: 'DatabaseUser - optional username used for heat DB, defaults
-                  to heat. TODO: -> implement needs work in mariadb-operator, right
-                  now only heat.'
                 type: string
               defaultConfigOverwrite:
                 additionalProperties:
@@ -254,7 +253,6 @@ spec:
               passwordSelectors:
                 default:
                   authEncryptionKey: HeatAuthEncryptionKey
-                  database: HeatDatabasePassword
                   service: HeatPassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
@@ -263,11 +261,6 @@ spec:
                     default: HeatAuthEncryptionKey
                     description: AuthEncryptionKey - Selector to get the heat auth
                       encryption key from the Secret
-                    type: string
-                  database:
-                    default: HeatDatabasePassword
-                    description: 'Database - Selector to get the heat Database user
-                      password from the Secret TODO: not used, need change in mariadb-operator'
                     type: string
                   service:
                     default: HeatPassword

--- a/config/crd/bases/heat.openstack.org_heatcfnapis.yaml
+++ b/config/crd/bases/heat.openstack.org_heatcfnapis.yaml
@@ -54,14 +54,13 @@ spec:
                   added to to /etc/<service>/<service>.conf.d directory as custom.conf
                   file.
                 type: string
+              databaseAccount:
+                default: heat
+                description: DatabaseAccount - optional MariaDBAccount used for heat
+                  DB, defaults to heat.
+                type: string
               databaseHostname:
                 description: DatabaseHostname - Heat Database Hostname
-                type: string
-              databaseUser:
-                default: heat
-                description: 'DatabaseUser - optional username used for heat DB, defaults
-                  to heat. TODO: -> implement needs work in mariadb-operator, right
-                  now only heat.'
                 type: string
               defaultConfigOverwrite:
                 additionalProperties:
@@ -254,7 +253,6 @@ spec:
               passwordSelectors:
                 default:
                   authEncryptionKey: HeatAuthEncryptionKey
-                  database: HeatDatabasePassword
                   service: HeatPassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
@@ -263,11 +261,6 @@ spec:
                     default: HeatAuthEncryptionKey
                     description: AuthEncryptionKey - Selector to get the heat auth
                       encryption key from the Secret
-                    type: string
-                  database:
-                    default: HeatDatabasePassword
-                    description: 'Database - Selector to get the heat Database user
-                      password from the Secret TODO: not used, need change in mariadb-operator'
                     type: string
                   service:
                     default: HeatPassword

--- a/config/crd/bases/heat.openstack.org_heatengines.yaml
+++ b/config/crd/bases/heat.openstack.org_heatengines.yaml
@@ -54,14 +54,13 @@ spec:
                   added to to /etc/<service>/<service>.conf.d directory as custom.conf
                   file.
                 type: string
+              databaseAccount:
+                default: heat
+                description: DatabaseAccount - optional MariaDBAccount used for heat
+                  DB, defaults to heat.
+                type: string
               databaseHostname:
                 description: DatabaseHostname - Heat Database Hostname
-                type: string
-              databaseUser:
-                default: heat
-                description: 'DatabaseUser - optional username used for heat DB, defaults
-                  to heat. TODO: -> implement needs work in mariadb-operator, right
-                  now only heat.'
                 type: string
               defaultConfigOverwrite:
                 additionalProperties:
@@ -80,7 +79,6 @@ spec:
               passwordSelectors:
                 default:
                   authEncryptionKey: HeatAuthEncryptionKey
-                  database: HeatDatabasePassword
                   service: HeatPassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
@@ -89,11 +87,6 @@ spec:
                     default: HeatAuthEncryptionKey
                     description: AuthEncryptionKey - Selector to get the heat auth
                       encryption key from the Secret
-                    type: string
-                  database:
-                    default: HeatDatabasePassword
-                    description: 'Database - Selector to get the heat Database user
-                      password from the Secret TODO: not used, need change in mariadb-operator'
                     type: string
                   service:
                     default: HeatPassword

--- a/config/crd/bases/heat.openstack.org_heats.yaml
+++ b/config/crd/bases/heat.openstack.org_heats.yaml
@@ -51,16 +51,15 @@ spec:
                   added to to /etc/<service>/<service>.conf.d directory as custom.conf
                   file.
                 type: string
+              databaseAccount:
+                default: heat
+                description: DatabaseAccount - optional MariaDBAccount used for heat
+                  DB, defaults to heat.
+                type: string
               databaseInstance:
                 description: MariaDB instance name. Right now required by the maridb-operator
                   to get the credentials from the instance to create the DB. Might
                   not be required in future.
-                type: string
-              databaseUser:
-                default: heat
-                description: 'DatabaseUser - optional username used for heat DB, defaults
-                  to heat. TODO: -> implement needs work in mariadb-operator, right
-                  now only heat.'
                 type: string
               defaultConfigOverwrite:
                 additionalProperties:
@@ -771,7 +770,6 @@ spec:
               passwordSelectors:
                 default:
                   authEncryptionKey: HeatAuthEncryptionKey
-                  database: HeatDatabasePassword
                   service: HeatPassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
@@ -780,11 +778,6 @@ spec:
                     default: HeatAuthEncryptionKey
                     description: AuthEncryptionKey - Selector to get the heat auth
                       encryption key from the Secret
-                    type: string
-                  database:
-                    default: HeatDatabasePassword
-                    description: 'Database - Selector to get the heat Database user
-                      password from the Secret TODO: not used, need change in mariadb-operator'
                     type: string
                   service:
                     default: HeatPassword

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -68,8 +68,12 @@ rules:
   resources:
   - secrets
   verbs:
+  - create
+  - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - ""

--- a/config/samples/heat_v1beta1_heatapi.yaml
+++ b/config/samples/heat_v1beta1_heatapi.yaml
@@ -4,7 +4,7 @@ metadata:
   name: heat-api
 spec:
   databaseHostname: openstack
-  databaseUser: heat
+  databaseAccount: heat
   passwordSelectors:
     authEncryptionKey: HeatAuthEncryptionKey
     database: HeatDatabasePassword

--- a/config/samples/heat_v1beta1_heatapicfn.yaml
+++ b/config/samples/heat_v1beta1_heatapicfn.yaml
@@ -4,7 +4,7 @@ metadata:
   name: heat-cfnapi
 spec:
   databaseHostname: openstack
-  databaseUser: heat
+  databaseAccount: heat
   passwordSelectors:
     authEncryptionKey: HeatAuthEncryptionKey
     database: HeatDatabasePassword

--- a/config/samples/heat_v1beta1_heatengine.yaml
+++ b/config/samples/heat_v1beta1_heatengine.yaml
@@ -4,7 +4,7 @@ metadata:
   name: heat-engine
 spec:
   databaseHostname: openstack
-  databaseUser: heat
+  databaseAccount: heat
   passwordSelectors:
     authEncryptionKey: HeatAuthEncryptionKey
     database: HeatDatabasePassword

--- a/controllers/heatcfnapi_controller.go
+++ b/controllers/heatcfnapi_controller.go
@@ -45,7 +45,6 @@ import (
 	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/lib-common/modules/common"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
-	"github.com/openstack-k8s-operators/lib-common/modules/common/configmap"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/deployment"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/endpoint"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
@@ -79,7 +78,7 @@ var keystoneCfnServices = []map[string]string{
 // +kubebuilder:rbac:groups=heat.openstack.org,resources=heatcfnapis/finalizers,verbs=update
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete;
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete;
-// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;create;update;patch;delete;watch
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete;
 // +kubebuilder:rbac:groups=keystone.openstack.org,resources=keystoneapis,verbs=get;list;watch;
 // +kubebuilder:rbac:groups=keystone.openstack.org,resources=keystoneservices,verbs=get;list;watch;create;update;patch;delete
@@ -607,29 +606,17 @@ func (r *HeatCfnAPIReconciler) reconcileNormal(ctx context.Context, instance *he
 	//
 	parentHeatName := heat.GetOwningHeatName(instance)
 
-	configMaps := []string{
-		fmt.Sprintf("%s-scripts", parentHeatName),     // ScriptsConfigMap
-		fmt.Sprintf("%s-config-data", parentHeatName), // ConfigMap
+	ctrlResult, err := r.getSecret(ctx, helper, instance, fmt.Sprintf("%s-scripts", parentHeatName), &configMapVars)
+	if err != nil {
+		return ctrlResult, err
+	}
+	ctrlResult, err = r.getSecret(ctx, helper, instance, fmt.Sprintf("%s-config-data", parentHeatName), &configMapVars)
+	// note r.getSecret adds Conditions with condition.InputReadyWaitingMessage
+	// when secret is not found
+	if err != nil {
+		return ctrlResult, err
 	}
 
-	_, err = configmap.GetConfigMaps(ctx, helper, instance, configMaps, instance.Namespace, &configMapVars)
-	if err != nil {
-		if k8s_errors.IsNotFound(err) {
-			instance.Status.Conditions.Set(condition.FalseCondition(
-				condition.InputReadyCondition,
-				condition.RequestedReason,
-				condition.SeverityInfo,
-				condition.InputReadyWaitingMessage))
-			return ctrl.Result{RequeueAfter: time.Second * 10}, fmt.Errorf("could not find all config maps for parent Heat CR %s", parentHeatName)
-		}
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.InputReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.InputReadyErrorMessage,
-			err.Error()))
-		return ctrl.Result{}, err
-	}
 	instance.Status.Conditions.MarkTrue(condition.InputReadyCondition, condition.InputReadyMessage)
 	// run check parent Heat CR config maps - end
 
@@ -810,6 +797,38 @@ func (r *HeatCfnAPIReconciler) reconcileUpgrade(ctx context.Context, instance *h
 	return ctrl.Result{}, nil
 }
 
+// getSecret - get the specified secret, and add its hash to envVars
+func (r *HeatCfnAPIReconciler) getSecret(
+	ctx context.Context,
+	h *helper.Helper,
+	instance *heatv1beta1.HeatCfnAPI,
+	secretName string,
+	envVars *map[string]env.Setter,
+) (ctrl.Result, error) {
+	secret, hash, err := secret.GetSecret(ctx, h, secretName, instance.Namespace)
+	if err != nil {
+		if k8s_errors.IsNotFound(err) {
+			instance.Status.Conditions.Set(condition.FalseCondition(
+				condition.InputReadyCondition,
+				condition.RequestedReason,
+				condition.SeverityInfo,
+				condition.InputReadyWaitingMessage))
+			return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, fmt.Errorf("Secret %s not found", secretName)
+		}
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			condition.InputReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			condition.InputReadyErrorMessage,
+			err.Error()))
+		return ctrl.Result{}, err
+	}
+
+	(*envVars)[secret.Name] = env.SetValue(hash)
+
+	return ctrl.Result{}, nil
+}
+
 // generateServiceConfigMaps - create custom configmap to hold service-specific config
 // TODO add DefaultConfigOverwrite
 func (r *HeatCfnAPIReconciler) generateServiceConfigMaps(
@@ -860,7 +879,7 @@ func (r *HeatCfnAPIReconciler) generateServiceConfigMaps(
 		},
 	}
 
-	return configmap.EnsureConfigMaps(ctx, h, instance, cms, envVars)
+	return secret.EnsureSecrets(ctx, h, instance, cms, envVars)
 }
 
 // createHashOfInputHashes - creates a hash of hashes which gets added to the resources which requires a restart

--- a/controllers/heatengine_controller.go
+++ b/controllers/heatengine_controller.go
@@ -43,7 +43,6 @@ import (
 	heatengine "github.com/openstack-k8s-operators/heat-operator/pkg/heatengine"
 	"github.com/openstack-k8s-operators/lib-common/modules/common"
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
-	configmap "github.com/openstack-k8s-operators/lib-common/modules/common/configmap"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/deployment"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
@@ -67,7 +66,7 @@ type HeatEngineReconciler struct {
 // +kubebuilder:rbac:groups=heat.openstack.org,resources=heatengines/finalizers,verbs=update
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete;
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete;
-// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;create;update;patch;delete;watch
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete;
 // +kubebuilder:rbac:groups=keystone.openstack.org,resources=keystoneapis,verbs=get;list;watch;
 
@@ -360,29 +359,17 @@ func (r *HeatEngineReconciler) reconcileNormal(
 	//
 	parentHeatName := heat.GetOwningHeatName(instance)
 
-	configMaps := []string{
-		fmt.Sprintf("%s-scripts", parentHeatName),     // ScriptsConfigMap
-		fmt.Sprintf("%s-config-data", parentHeatName), // ConfigMap
+	ctrlResult, err := r.getSecret(ctx, helper, instance, fmt.Sprintf("%s-scripts", parentHeatName), &configMapVars)
+	if err != nil {
+		return ctrlResult, err
+	}
+	ctrlResult, err = r.getSecret(ctx, helper, instance, fmt.Sprintf("%s-config-data", parentHeatName), &configMapVars)
+	// note r.getSecret adds Conditions with condition.InputReadyWaitingMessage
+	// when secret is not found
+	if err != nil {
+		return ctrlResult, err
 	}
 
-	_, err = configmap.GetConfigMaps(ctx, helper, instance, configMaps, instance.Namespace, &configMapVars)
-	if err != nil {
-		if k8s_errors.IsNotFound(err) {
-			instance.Status.Conditions.Set(condition.FalseCondition(
-				condition.InputReadyCondition,
-				condition.RequestedReason,
-				condition.SeverityInfo,
-				condition.InputReadyWaitingMessage))
-			return ctrl.Result{RequeueAfter: time.Second * 10}, fmt.Errorf("could not find all config maps for parent heat CR %s", parentHeatName)
-		}
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.InputReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.InputReadyErrorMessage,
-			err.Error()))
-		return ctrl.Result{}, err
-	}
 	instance.Status.Conditions.MarkTrue(condition.InputReadyCondition, condition.InputReadyMessage)
 	// run check parent heat CR config maps - end
 
@@ -459,7 +446,7 @@ func (r *HeatEngineReconciler) reconcileNormal(
 	}
 
 	// Handle service init
-	ctrlResult, err := r.reconcileInit(ctx, instance, helper, serviceLabels)
+	ctrlResult, err = r.reconcileInit(ctx, instance, helper, serviceLabels)
 	if err != nil || (ctrlResult != ctrl.Result{}) {
 		return ctrlResult, err
 	}
@@ -528,6 +515,38 @@ func (r *HeatEngineReconciler) reconcileUpgrade(ctx context.Context, instance *h
 	return ctrl.Result{}, nil
 }
 
+// getSecret - get the specified secret, and add its hash to envVars
+func (r *HeatEngineReconciler) getSecret(
+	ctx context.Context,
+	h *helper.Helper,
+	instance *heatv1beta1.HeatEngine,
+	secretName string,
+	envVars *map[string]env.Setter,
+) (ctrl.Result, error) {
+	secret, hash, err := secret.GetSecret(ctx, h, secretName, instance.Namespace)
+	if err != nil {
+		if k8s_errors.IsNotFound(err) {
+			instance.Status.Conditions.Set(condition.FalseCondition(
+				condition.InputReadyCondition,
+				condition.RequestedReason,
+				condition.SeverityInfo,
+				condition.InputReadyWaitingMessage))
+			return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, fmt.Errorf("Secret %s not found", secretName)
+		}
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			condition.InputReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			condition.InputReadyErrorMessage,
+			err.Error()))
+		return ctrl.Result{}, err
+	}
+
+	(*envVars)[secret.Name] = env.SetValue(hash)
+
+	return ctrl.Result{}, nil
+}
+
 // generateServiceConfigMaps - create custom configmap to hold service-specific config
 // TODO add DefaultConfigOverwrite
 func (r *HeatEngineReconciler) generateServiceConfigMaps(
@@ -578,7 +597,7 @@ func (r *HeatEngineReconciler) generateServiceConfigMaps(
 		},
 	}
 
-	return configmap.EnsureConfigMaps(ctx, h, instance, cms, envVars)
+	return secret.EnsureSecrets(ctx, h, instance, cms, envVars)
 }
 
 // createHashOfInputHashes - creates a hash of hashes which gets added to the resources which requires a restart

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240216173409-86913e6d5885
 	github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.20240216173409-86913e6d5885
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240216173409-86913e6d5885
-	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240219072536-62f6b4dc7798
+	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240303091826-438dde8600d3
 	k8s.io/api v0.28.7
 	k8s.io/apimachinery v0.28.7
 	k8s.io/client-go v0.28.7

--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,8 @@ github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.2024021
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.20240216173409-86913e6d5885/go.mod h1:8QsCFttAm+X6A8I8EQThGjNjeMAYt2hK7ivbvnR3434=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240216173409-86913e6d5885 h1:ioJ2MO3vAcBkLM+0UBu5IuKW/DPXcyiNSOLq0Xvn+Nw=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240216173409-86913e6d5885/go.mod h1:82nzS+DbBe1tzaMvNHH8FctmZzQ14ZAJysFGsMJiivo=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240219072536-62f6b4dc7798 h1:zL4DdQ5HPXCLHeRMAWC2zI7ypbkZVYg3UkyEFSnzeow=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240219072536-62f6b4dc7798/go.mod h1:PDqfLbP4ZWqQHAu1OtbjfpOGQUKSzLqRJChvE/9pcyQ=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240303091826-438dde8600d3 h1:fwb+GvvnN9Mhkgg5pBksZ8W5+hLCcNOorHsUTQYA1Lg=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240303091826-438dde8600d3/go.mod h1:f9IIyWeoskWoeWaDFF3qmAJ2Kqyovfi0Ar/QUfk3qag=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/pkg/heat/dbsync.go
+++ b/pkg/heat/dbsync.go
@@ -88,10 +88,8 @@ func DBSyncJob(
 	initContainerDetails := APIDetails{
 		ContainerImage:            instance.Spec.HeatAPI.ContainerImage,
 		DatabaseHost:              instance.Status.DatabaseHostname,
-		DatabaseUser:              instance.Spec.DatabaseUser,
 		DatabaseName:              DatabaseName,
 		OSPSecret:                 instance.Spec.Secret,
-		DBPasswordSelector:        instance.Spec.PasswordSelectors.Database,
 		UserPasswordSelector:      instance.Spec.PasswordSelectors.Service,
 		AuthEncryptionKeySelector: instance.Spec.PasswordSelectors.AuthEncryptionKey,
 		VolumeMounts:              initVolumeMounts,

--- a/pkg/heat/initcontainer.go
+++ b/pkg/heat/initcontainer.go
@@ -25,11 +25,9 @@ import (
 type APIDetails struct {
 	ContainerImage            string
 	DatabaseHost              string
-	DatabaseUser              string
 	DatabaseName              string
 	TransportURL              string
 	OSPSecret                 string
-	DBPasswordSelector        string
 	UserPasswordSelector      string
 	AuthEncryptionKeySelector string
 	VolumeMounts              []corev1.VolumeMount
@@ -56,21 +54,9 @@ func InitContainer(init APIDetails) []corev1.Container {
 
 	envVars := map[string]env.Setter{}
 	envVars["DatabaseHost"] = env.SetValue(init.DatabaseHost)
-	envVars["DatabaseUser"] = env.SetValue(init.DatabaseUser)
 	envVars["DatabaseName"] = env.SetValue(init.DatabaseName)
 
 	envs := []corev1.EnvVar{
-		{
-			Name: "DatabasePassword",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: init.OSPSecret,
-					},
-					Key: init.DBPasswordSelector,
-				},
-			},
-		},
 		{
 			Name: "HeatPassword",
 			ValueFrom: &corev1.EnvVarSource{

--- a/pkg/heat/volumes.go
+++ b/pkg/heat/volumes.go
@@ -28,22 +28,18 @@ func GetVolumes(name string) []corev1.Volume {
 		{
 			Name: "scripts",
 			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
+				Secret: &corev1.SecretVolumeSource{
 					DefaultMode: &scriptsVolumeDefaultMode,
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: name + "-scripts",
-					},
+					SecretName:  name + "-scripts",
 				},
 			},
 		},
 		{
 			Name: "config-data",
 			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
+				Secret: &corev1.SecretVolumeSource{
 					DefaultMode: &config0640AccessMode,
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: name + "-config-data",
-					},
+					SecretName:  name + "-config-data",
 				},
 			},
 		},

--- a/pkg/heatapi/deployment.go
+++ b/pkg/heatapi/deployment.go
@@ -169,10 +169,8 @@ func Deployment(
 	initContainerDetails := heat.APIDetails{
 		ContainerImage:            instance.Spec.ContainerImage,
 		DatabaseHost:              instance.Spec.DatabaseHostname,
-		DatabaseUser:              instance.Spec.DatabaseUser,
 		DatabaseName:              heat.DatabaseName,
 		OSPSecret:                 instance.Spec.Secret,
-		DBPasswordSelector:        instance.Spec.PasswordSelectors.Database,
 		UserPasswordSelector:      instance.Spec.PasswordSelectors.Service,
 		AuthEncryptionKeySelector: instance.Spec.PasswordSelectors.AuthEncryptionKey,
 		VolumeMounts:              initVolumeMounts,

--- a/pkg/heatapi/volumes.go
+++ b/pkg/heatapi/volumes.go
@@ -13,11 +13,9 @@ func getVolumes(parentName string, name string) []corev1.Volume {
 		{
 			Name: "config-data-custom",
 			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
+				Secret: &corev1.SecretVolumeSource{
 					DefaultMode: &config0640AccessMode,
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: name + "-config-data",
-					},
+					SecretName:  name + "-config-data",
 				},
 			},
 		},

--- a/pkg/heatcfnapi/deployment.go
+++ b/pkg/heatcfnapi/deployment.go
@@ -169,10 +169,8 @@ func Deployment(
 	initContainerDetails := heat.APIDetails{
 		ContainerImage:            instance.Spec.ContainerImage,
 		DatabaseHost:              instance.Spec.DatabaseHostname,
-		DatabaseUser:              instance.Spec.DatabaseUser,
 		DatabaseName:              heat.DatabaseName,
 		OSPSecret:                 instance.Spec.Secret,
-		DBPasswordSelector:        instance.Spec.PasswordSelectors.Database,
 		UserPasswordSelector:      instance.Spec.PasswordSelectors.Service,
 		AuthEncryptionKeySelector: instance.Spec.PasswordSelectors.AuthEncryptionKey,
 		VolumeMounts:              initVolumeMounts,

--- a/pkg/heatcfnapi/volumes.go
+++ b/pkg/heatcfnapi/volumes.go
@@ -13,11 +13,9 @@ func getVolumes(parentName string, name string) []corev1.Volume {
 		{
 			Name: "config-data-custom",
 			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
+				Secret: &corev1.SecretVolumeSource{
 					DefaultMode: &config0640AccessMode,
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: name + "-config-data",
-					},
+					SecretName:  name + "-config-data",
 				},
 			},
 		},

--- a/pkg/heatengine/deployment.go
+++ b/pkg/heatengine/deployment.go
@@ -139,10 +139,8 @@ func Deployment(instance *heatv1beta1.HeatEngine, configHash string, labels map[
 	initContainerDetails := heat.APIDetails{
 		ContainerImage:            instance.Spec.ContainerImage,
 		DatabaseHost:              instance.Spec.DatabaseHostname,
-		DatabaseUser:              instance.Spec.DatabaseUser,
 		DatabaseName:              heat.DatabaseName,
 		OSPSecret:                 instance.Spec.Secret,
-		DBPasswordSelector:        instance.Spec.PasswordSelectors.Database,
 		UserPasswordSelector:      instance.Spec.PasswordSelectors.Service,
 		AuthEncryptionKeySelector: instance.Spec.PasswordSelectors.AuthEncryptionKey,
 		VolumeMounts:              initVolumeMounts,

--- a/pkg/heatengine/volumes.go
+++ b/pkg/heatengine/volumes.go
@@ -13,11 +13,9 @@ func getVolumes(parentName string, name string) []corev1.Volume {
 		{
 			Name: "config-data-custom",
 			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
+				Secret: &corev1.SecretVolumeSource{
 					DefaultMode: &config0640AccessMode,
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: name + "-config-data",
-					},
+					SecretName:  name + "-config-data",
 				},
 			},
 		},

--- a/templates/heat/bin/init.sh
+++ b/templates/heat/bin/init.sh
@@ -16,10 +16,6 @@
 set -ex
 
 # Secrets are obtained from ENV variables.
-export DB=${DatabaseName:-"heat"}
-export DBHOST=${DatabaseHost:?"Please specify a DatabaseHost variable."}
-export DBUSER=${DatabaseUser:-"heat"}
-export DBPASSWORD=${DatabasePassword:?"Please specify a DatabasePassword variable."}
 export PASSWORD=${HeatPassword:?"Please specify a HeatPassword variable."}
 export TRANSPORT_URL=${TransportURL:-""}
 export AUTH_ENCRYPTION_KEY=${AuthEncryptionKey:-""}
@@ -73,7 +69,6 @@ if [ -n "$AUTH_ENCRYPTION_KEY" ]; then
     crudini --set ${SVC_CFG_MERGED} DEFAULT auth_encryption_key $AUTH_ENCRYPTION_KEY
 fi
 
-crudini --set ${SVC_CFG_MERGED} database connection mysql+pymysql://${DBUSER}:${DBPASSWORD}@${DBHOST}/${DB}?read_default_file=/etc/my.cnf
 crudini --set ${SVC_CFG_MERGED} keystone_authtoken password $PASSWORD
 crudini --set ${SVC_CFG_MERGED} DEFAULT stack_domain_admin_password $PASSWORD
 crudini --set ${SVC_CFG_MERGED} trustee password $PASSWORD

--- a/templates/heat/config/heat.conf
+++ b/templates/heat/config/heat.conf
@@ -13,7 +13,7 @@ enabled=true
 memcache_servers={{ .MemcachedServers }}
 
 [database]
-#connection =
+connection={{ .DatabaseConnection }}
 max_retries=-1
 db_max_retries=-1
 

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -75,9 +75,8 @@ func CreateHeatSecret(namespace string, name string) *corev1.Secret {
 	return th.CreateSecret(
 		types.NamespacedName{Namespace: namespace, Name: name},
 		map[string][]byte{
-			"HeatPassword":         []byte("12345678"),
-			"HeatDatabasePassword": []byte("12345678"),
-			"AuthEncryptionKey":    []byte("1234567812345678123456781212345678345678"),
+			"HeatPassword":      []byte("12345678"),
+			"AuthEncryptionKey": []byte("1234567812345678123456781212345678345678"),
 		},
 	)
 }

--- a/tests/kuttl/common/assert-sample-deployment.yaml
+++ b/tests/kuttl/common/assert-sample-deployment.yaml
@@ -19,7 +19,7 @@ spec:
     [DEFAULT]
     debug = True
   databaseInstance: openstack
-  databaseUser: "heat"
+  databaseAccount: "heat"
   heatAPI:
     replicas: 1
     resources: {}
@@ -33,7 +33,6 @@ spec:
   passwordSelectors:
     authEncryptionKey: HeatAuthEncryptionKey
     service: HeatPassword
-    database: HeatDatabasePassword
   preserveJobs: false
   rabbitMqClusterName: rabbitmq
   secret: osp-secret
@@ -59,10 +58,9 @@ metadata:
       name: heat
 spec:
   databaseHostname: openstack.heat-kuttl-tests.svc
-  databaseUser: heat
+  databaseAccount: heat
   passwordSelectors:
     authEncryptionKey: HeatAuthEncryptionKey
-    database: HeatDatabasePassword
     service: HeatPassword
   replicas: 1
   resources: {}
@@ -87,10 +85,9 @@ metadata:
       name: heat
 spec:
   databaseHostname: openstack.heat-kuttl-tests.svc
-  databaseUser: heat
+  databaseAccount: heat
   passwordSelectors:
     authEncryptionKey: HeatAuthEncryptionKey
-    database: HeatDatabasePassword
     service: HeatPassword
   replicas: 1
   resources: {}
@@ -115,10 +112,9 @@ metadata:
       name: heat
 spec:
   databaseHostname: openstack.heat-kuttl-tests.svc
-  databaseUser: heat
+  databaseAccount: heat
   passwordSelectors:
     authEncryptionKey: HeatAuthEncryptionKey
-    database: HeatDatabasePassword
     service: HeatPassword
   replicas: 1
   resources: {}

--- a/tests/kuttl/tests/heat_tls/01-assert.yaml
+++ b/tests/kuttl/tests/heat_tls/01-assert.yaml
@@ -147,20 +147,20 @@ spec:
           readOnly: true
           subPath: tls-ca-bundle.pem
       volumes:
-      - configMap:
+      - name: scripts
+        secret:
           defaultMode: 493
-          name: heat-scripts
-        name: scripts
-      - configMap:
+          secretName: heat-scripts
+      - name: config-data
+        secret:
           defaultMode: 416
-          name: heat-config-data
-        name: config-data
+          secretName: heat-config-data
       - emptyDir: {}
         name: config-data-merged
-      - configMap:
+      - name: config-data-custom
+        secret:
           defaultMode: 416
-          name: heat-api-config-data
-        name: config-data-custom
+          secretName: heat-api-config-data
       - name: combined-ca-bundle
         secret:
           defaultMode: 292
@@ -244,20 +244,20 @@ spec:
           readOnly: true
           subPath: tls-ca-bundle.pem
       volumes:
-      - configMap:
+      - name: scripts
+        secret:
           defaultMode: 493
-          name: heat-scripts
-        name: scripts
-      - configMap:
+          secretName: heat-scripts
+      - name: config-data
+        secret:
           defaultMode: 416
-          name: heat-config-data
-        name: config-data
+          secretName: heat-config-data
       - emptyDir: {}
         name: config-data-merged
-      - configMap:
+      - name: config-data-custom
+        secret:
           defaultMode: 416
-          name: heat-cfnapi-config-data
-        name: config-data-custom
+          secretName: heat-cfnapi-config-data
       - name: combined-ca-bundle
         secret:
           defaultMode: 292
@@ -325,20 +325,20 @@ spec:
           readOnly: true
           subPath: tls-ca-bundle.pem
       volumes:
-      - configMap:
+      - name: scripts
+        secret:
           defaultMode: 493
-          name: heat-scripts
-        name: scripts
-      - configMap:
+          secretName: heat-scripts
+      - name: config-data
+        secret:
           defaultMode: 416
-          name: heat-config-data
-        name: config-data
+          secretName: heat-config-data
       - emptyDir: {}
         name: config-data-merged
-      - configMap:
+      - name: config-data-custom
+        secret:
           defaultMode: 416
-          name: heat-engine-config-data
-        name: config-data-custom
+          secretName: heat-engine-config-data
       - name: combined-ca-bundle
         secret:
           defaultMode: 292


### PR DESCRIPTION
This moves heat to fully use MariaDBAccount based on the dev work being done for mariadb-operator:

Lead Jira: [OSPRH-4095](https://issues.redhat.com/browse/OSPRH-4095)

1. [x] controller calls EnsureMariaDBAccount up front to make sure MariaDBAccount is present
2. [x] error code from EnsureMariaDBAccount is handled, Conditions are amended when error is returned
3. [x] controller calls NewDatabaseForAccount instead of NewDatabase
4. [x]  GetAccountAndSecret is used to retrieve account /secret to populate template
5. [x]  GetDatabaseByName() , normally used for delete finalizers, replaced with GetDatabaseByNameAndAccount
6. [x]  CreateOrPatchAll() used to patch the Database, replacing CreateOrPatchDB / CreateOrPatchDBByName
7. [x]  controller calls DeleteUnusedMariaDBAccountFinalizers when launched pods are definitely running on a new MariaDBAccount, returns error code if present
8. [x]  PasswordSelectors that refer to database are removed
9. [x]  all databaseUser replaced with databaseAccount inside of all XYZ_types.go
10. [x] all databaseUser replaced with databaseAccount inside of all `kuttl/*.yaml`
11. [x] all default databaseUser names become databaseAccount, replacing underscores with dashes inside of all XYZ_types.go
12. [x] all default databaseUser names become databaseAccount, replacing underscores with dashes inside of all `kuttl/*.yaml`
13. [x] MariaDBAccountSuiteTests are used in controller ginkgo tests if it has them
14. [x] Use configsecrets for database URLs; remove from job hash
13. [x] [184](https://github.com/openstack-k8s-operators/mariadb-operator/pull/184) is merged and replaces from go.mod are removed 

