### PR TITLE
[tlse] TLS database connection

### DIFF
--- a/controllers/heatapi_controller.go
+++ b/controllers/heatapi_controller.go
@@ -55,6 +55,7 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/service"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/tls"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
+	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 )
 
 // HeatAPIReconciler reconciles a Heat object
@@ -820,10 +821,22 @@ func (r *HeatAPIReconciler) generateServiceConfigMaps(
 
 	cmLabels := labels.GetLabels(instance, labels.GetGroupLabel(heat.ServiceName), map[string]string{})
 
+	db, err := mariadbv1.GetDatabaseByName(ctx, h, heat.DatabaseName)
+	if err != nil {
+		return err
+	}
+	var tlsCfg *tls.Service
+	if instance.Spec.TLS.Ca.CaBundleSecretName != "" {
+		tlsCfg = &tls.Service{}
+	}
+
 	// customData hold any customization for the service.
 	// custom.conf is going to /etc/heat/heat.conf.d
 	// TODO: make sure custom.conf can not be overwritten
-	customData := map[string]string{common.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig}
+	customData := map[string]string{
+		common.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig,
+		"my.cnf":                           db.GetDatabaseClientConfig(tlsCfg), //(mschuppert) for now just get the default my.cnf
+	}
 
 	for key, data := range instance.Spec.DefaultConfigOverwrite {
 		customData[key] = data

--- a/controllers/heatcfnapi_controller.go
+++ b/controllers/heatcfnapi_controller.go
@@ -55,6 +55,7 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/service"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/tls"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
+	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 )
 
 // HeatCfnAPIReconciler reconciles a Heat object
@@ -824,10 +825,22 @@ func (r *HeatCfnAPIReconciler) generateServiceConfigMaps(
 
 	cmLabels := labels.GetLabels(instance, labels.GetGroupLabel(heat.CfnServiceName), map[string]string{})
 
+	db, err := mariadbv1.GetDatabaseByName(ctx, h, heat.DatabaseName)
+	if err != nil {
+		return err
+	}
+	var tlsCfg *tls.Service
+	if instance.Spec.TLS.Ca.CaBundleSecretName != "" {
+		tlsCfg = &tls.Service{}
+	}
+
 	// customData hold any customization for the service.
 	// custom.conf is going to /etc/heat/heat.conf.d
 	// TODO: make sure custom.conf can not be overwritten
-	customData := map[string]string{common.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig}
+	customData := map[string]string{
+		common.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig,
+		"my.cnf":                           db.GetDatabaseClientConfig(tlsCfg), //(mschuppert) for now just get the default my.cnf
+	}
 
 	for key, data := range instance.Spec.DefaultConfigOverwrite {
 		customData[key] = data

--- a/pkg/heat/volumes.go
+++ b/pkg/heat/volumes.go
@@ -74,6 +74,12 @@ func GetInitVolumeMounts() []corev1.VolumeMount {
 			MountPath: "/var/lib/config-data/merged",
 			ReadOnly:  false,
 		},
+		{
+			Name:      "config-data",
+			MountPath: "/etc/my.cnf",
+			SubPath:   "my.cnf",
+			ReadOnly:  true,
+		},
 	}
 
 }
@@ -90,6 +96,12 @@ func GetVolumeMounts() []corev1.VolumeMount {
 			Name:      "config-data-merged",
 			MountPath: "/var/lib/config-data/merged",
 			ReadOnly:  false,
+		},
+		{
+			Name:      "config-data",
+			MountPath: "/etc/my.cnf",
+			SubPath:   "my.cnf",
+			ReadOnly:  true,
 		},
 	}
 }

--- a/templates/heat/bin/init.sh
+++ b/templates/heat/bin/init.sh
@@ -73,7 +73,7 @@ if [ -n "$AUTH_ENCRYPTION_KEY" ]; then
     crudini --set ${SVC_CFG_MERGED} DEFAULT auth_encryption_key $AUTH_ENCRYPTION_KEY
 fi
 
-crudini --set ${SVC_CFG_MERGED} database connection mysql+pymysql://${DBUSER}:${DBPASSWORD}@${DBHOST}/${DB}
+crudini --set ${SVC_CFG_MERGED} database connection mysql+pymysql://${DBUSER}:${DBPASSWORD}@${DBHOST}/${DB}?read_default_file=/etc/my.cnf
 crudini --set ${SVC_CFG_MERGED} keystone_authtoken password $PASSWORD
 crudini --set ${SVC_CFG_MERGED} DEFAULT stack_domain_admin_password $PASSWORD
 crudini --set ${SVC_CFG_MERGED} trustee password $PASSWORD

--- a/tests/kuttl/tests/heat_tls/01-assert.yaml
+++ b/tests/kuttl/tests/heat_tls/01-assert.yaml
@@ -95,6 +95,10 @@ spec:
           readOnly: true
         - mountPath: /var/lib/config-data/merged
           name: config-data-merged
+        - mountPath: /etc/my.cnf
+          name: config-data
+          readOnly: true
+          subPath: my.cnf
         - mountPath: /var/lib/kolla/config_files/config.json
           name: config-data-merged
           readOnly: true
@@ -131,6 +135,10 @@ spec:
           readOnly: true
         - mountPath: /var/lib/config-data/merged
           name: config-data-merged
+        - mountPath: /etc/my.cnf
+          name: config-data
+          readOnly: true
+          subPath: my.cnf
         - mountPath: /var/lib/config-data/custom
           name: config-data-custom
           readOnly: true
@@ -184,6 +192,10 @@ spec:
           readOnly: true
         - mountPath: /var/lib/config-data/merged
           name: config-data-merged
+        - mountPath: /etc/my.cnf
+          name: config-data
+          readOnly: true
+          subPath: my.cnf
         - mountPath: /var/lib/kolla/config_files/config.json
           name: config-data-merged
           readOnly: true
@@ -220,6 +232,10 @@ spec:
           readOnly: true
         - mountPath: /var/lib/config-data/merged
           name: config-data-merged
+        - mountPath: /etc/my.cnf
+          name: config-data
+          readOnly: true
+          subPath: my.cnf
         - mountPath: /var/lib/config-data/custom
           name: config-data-custom
           readOnly: true
@@ -273,6 +289,10 @@ spec:
           readOnly: true
         - mountPath: /var/lib/config-data/merged
           name: config-data-merged
+        - mountPath: /etc/my.cnf
+          name: config-data
+          readOnly: true
+          subPath: my.cnf
         - mountPath: /var/lib/kolla/config_files/config.json
           name: config-data-merged
           readOnly: true
@@ -293,6 +313,10 @@ spec:
           readOnly: true
         - mountPath: /var/lib/config-data/merged
           name: config-data-merged
+        - mountPath: /etc/my.cnf
+          name: config-data
+          readOnly: true
+          subPath: my.cnf
         - mountPath: /var/lib/config-data/custom
           name: config-data-custom
           readOnly: true


### PR DESCRIPTION
The my.cnf file gets added to the secret holding the service configs. The content of my.cnf is centrally managed in the mariadb-operator and retrieved calling db.GetDatabaseClientConfig(tlsCfg)

Depends-On: https://github.com/openstack-k8s-operators/mariadb-operator/pull/190
Depends-On: https://github.com/openstack-k8s-operators/mariadb-operator/pull/191

Jira: [OSPRH-4547](https://issues.redhat.com//browse/OSPRH-4547)