### PR TITLE
Refactor use of GetDatabaseByName to GetDatabaseByNameAndAccount

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,8 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	# TODO: revisit pinned version once https://github.com/kubernetes-sigs/controller-runtime/issues/2720 is fixed
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@c7e1dc9b
 
 .PHONY: ginkgo
 ginkgo: $(GINKGO) ## Download ginkgo locally if necessary.

--- a/controllers/heatapi_controller.go
+++ b/controllers/heatapi_controller.go
@@ -842,7 +842,7 @@ func (r *HeatAPIReconciler) generateServiceConfigMaps(
 
 	cmLabels := labels.GetLabels(instance, labels.GetGroupLabel(heat.ServiceName), map[string]string{})
 
-	db, err := mariadbv1.GetDatabaseByName(ctx, h, heat.DatabaseName)
+	db, err := mariadbv1.GetDatabaseByNameAndAccount(ctx, h, instance.Name, instance.Spec.DatabaseAccount, instance.Namespace)
 	if err != nil {
 		return err
 	}

--- a/controllers/heatcfnapi_controller.go
+++ b/controllers/heatcfnapi_controller.go
@@ -844,7 +844,7 @@ func (r *HeatCfnAPIReconciler) generateServiceConfigMaps(
 
 	cmLabels := labels.GetLabels(instance, labels.GetGroupLabel(heat.CfnServiceName), map[string]string{})
 
-	db, err := mariadbv1.GetDatabaseByName(ctx, h, heat.DatabaseName)
+	db, err := mariadbv1.GetDatabaseByNameAndAccount(ctx, h, instance.Name, instance.Spec.DatabaseAccount, instance.Namespace)
 	if err != nil {
 		return err
 	}

--- a/controllers/heatengine_controller.go
+++ b/controllers/heatengine_controller.go
@@ -562,7 +562,7 @@ func (r *HeatEngineReconciler) generateServiceConfigMaps(
 
 	cmLabels := labels.GetLabels(instance, labels.GetGroupLabel(heat.ServiceName), map[string]string{})
 
-	db, err := mariadbv1.GetDatabaseByName(ctx, h, heat.DatabaseName)
+	db, err := mariadbv1.GetDatabaseByNameAndAccount(ctx, h, instance.Name, instance.Spec.DatabaseAccount, instance.Namespace)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This change refactors the use of all GetDatabaseByName() calls to use the new GetDatabaseByNameAndAccount() helper function.