### PR TITLE
Refactor getdatabase use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,8 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	# TODO: revisit pinned version once https://github.com/kubernetes-sigs/controller-runtime/issues/2720 is fixed
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@c7e1dc9b
 
 .PHONY: ginkgo
 ginkgo: $(GINKGO) ## Download ginkgo locally if necessary.

--- a/controllers/heat_controller.go
+++ b/controllers/heat_controller.go
@@ -334,7 +334,7 @@ func (r *HeatReconciler) reconcileDelete(ctx context.Context, instance *heatv1be
 	r.Log.Info("Reconciling Heat delete")
 
 	// remove db finalizer first
-	db, err := mariadbv1.GetDatabaseByNameAndAccount(ctx, helper, instance.Name, instance.Spec.DatabaseAccount, instance.Namespace)
+	db, err := mariadbv1.GetDatabaseByNameAndAccount(ctx, helper, heat.DatabaseCRName, instance.Spec.DatabaseAccount, instance.Namespace)
 	if err != nil && !k8s_errors.IsNotFound(err) {
 		return ctrl.Result{}, err
 	}
@@ -579,7 +579,7 @@ func (r *HeatReconciler) reconcileNormal(ctx context.Context, instance *heatv1be
 	// a new MariaDBAccount is created and an old MariaDBAccount is marked
 	// deleted at once, where the finalizer will keep the old one around until
 	// it's safe to drop.
-	err = mariadbv1.DeleteUnusedMariaDBAccountFinalizers(ctx, helper, instance.Name, instance.Spec.DatabaseAccount, instance.Namespace)
+	err = mariadbv1.DeleteUnusedMariaDBAccountFinalizers(ctx, helper, heat.DatabaseCRName, instance.Spec.DatabaseAccount, instance.Namespace)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -1091,7 +1091,7 @@ func (r *HeatReconciler) ensureDB(
 	// yet associated with any MariaDBDatabase.
 	_, _, err := mariadbv1.EnsureMariaDBAccount(
 		ctx, h, instance.Spec.DatabaseAccount,
-		instance.Namespace, false, "heat",
+		instance.Namespace, false, heat.DatabaseUsernamePrefix,
 	)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
@@ -1114,7 +1114,7 @@ func (r *HeatReconciler) ensureDB(
 	db := mariadbv1.NewDatabaseForAccount(
 		instance.Spec.DatabaseInstance, // mariadb/galera service to target
 		heat.DatabaseName,              // name used in CREATE DATABASE in mariadb
-		instance.Name,                  // CR name for MariaDBDatabase
+		heat.DatabaseCRName,            // CR name for MariaDBDatabase
 		instance.Spec.DatabaseAccount,  // CR name for MariaDBAccount
 		instance.Namespace,             // namespace
 	)

--- a/controllers/heatapi_controller.go
+++ b/controllers/heatapi_controller.go
@@ -842,7 +842,7 @@ func (r *HeatAPIReconciler) generateServiceConfigMaps(
 
 	cmLabels := labels.GetLabels(instance, labels.GetGroupLabel(heat.ServiceName), map[string]string{})
 
-	db, err := mariadbv1.GetDatabaseByName(ctx, h, heat.DatabaseName)
+	db, err := mariadbv1.GetDatabaseByNameAndAccount(ctx, h, heat.DatabaseCRName, instance.Spec.DatabaseAccount, instance.Namespace)
 	if err != nil {
 		return err
 	}

--- a/controllers/heatcfnapi_controller.go
+++ b/controllers/heatcfnapi_controller.go
@@ -844,7 +844,7 @@ func (r *HeatCfnAPIReconciler) generateServiceConfigMaps(
 
 	cmLabels := labels.GetLabels(instance, labels.GetGroupLabel(heat.CfnServiceName), map[string]string{})
 
-	db, err := mariadbv1.GetDatabaseByName(ctx, h, heat.DatabaseName)
+	db, err := mariadbv1.GetDatabaseByNameAndAccount(ctx, h, heat.DatabaseCRName, instance.Spec.DatabaseAccount, instance.Namespace)
 	if err != nil {
 		return err
 	}

--- a/controllers/heatengine_controller.go
+++ b/controllers/heatengine_controller.go
@@ -562,7 +562,7 @@ func (r *HeatEngineReconciler) generateServiceConfigMaps(
 
 	cmLabels := labels.GetLabels(instance, labels.GetGroupLabel(heat.ServiceName), map[string]string{})
 
-	db, err := mariadbv1.GetDatabaseByName(ctx, h, heat.DatabaseName)
+	db, err := mariadbv1.GetDatabaseByNameAndAccount(ctx, h, heat.DatabaseCRName, instance.Spec.DatabaseAccount, instance.Namespace)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240216173409-86913e6d5885
 	github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.20240216173409-86913e6d5885
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240216173409-86913e6d5885
-	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240303091826-438dde8600d3
+	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240314113200-40cf3e6aa38e
 	k8s.io/api v0.28.8
 	k8s.io/apimachinery v0.28.8
 	k8s.io/client-go v0.28.8

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,8 @@ github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.2024021
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.20240216173409-86913e6d5885/go.mod h1:8QsCFttAm+X6A8I8EQThGjNjeMAYt2hK7ivbvnR3434=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240216173409-86913e6d5885 h1:ioJ2MO3vAcBkLM+0UBu5IuKW/DPXcyiNSOLq0Xvn+Nw=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240216173409-86913e6d5885/go.mod h1:82nzS+DbBe1tzaMvNHH8FctmZzQ14ZAJysFGsMJiivo=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240303091826-438dde8600d3 h1:fwb+GvvnN9Mhkgg5pBksZ8W5+hLCcNOorHsUTQYA1Lg=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240303091826-438dde8600d3/go.mod h1:f9IIyWeoskWoeWaDFF3qmAJ2Kqyovfi0Ar/QUfk3qag=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240314113200-40cf3e6aa38e h1:HUJV2Rd0NQZAXwV0UNdHKjO7fY5QLlDuLdI9f/OIc0Y=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240314113200-40cf3e6aa38e/go.mod h1:f9IIyWeoskWoeWaDFF3qmAJ2Kqyovfi0Ar/QUfk3qag=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/pkg/heat/const.go
+++ b/pkg/heat/const.go
@@ -30,8 +30,17 @@ const (
 	StackDomainAdminUsername = "heat_stack_domain_admin"
 	// StackDomainName -
 	StackDomainName = "heat_stack"
-	// DatabaseName -
+
+	// DatabaseCRName - Name of the MariaDBDatabase CR
+	DatabaseCRName = "heat"
+
+	// Database - Name of the database used in CREATE DATABASE statement
 	DatabaseName = "heat"
+
+	// DatabaseUsernamePrefix - used by EnsureMariaDBAccount when a new username
+	// is to be generated, e.g. "heat_e5a4", "heat_78bc", etc
+	DatabaseUsernamePrefix = "heat"
+
 	// HeatPublicPort -
 	HeatPublicPort int32 = 8004
 	// HeatInternalPort -

--- a/tests/functional/heat_controller_test.go
+++ b/tests/functional/heat_controller_test.go
@@ -30,6 +30,7 @@ import (
 	mariadb_test "github.com/openstack-k8s-operators/mariadb-operator/api/test/helpers"
 
 	heatv1 "github.com/openstack-k8s-operators/heat-operator/api/v1beta1"
+	"github.com/openstack-k8s-operators/heat-operator/pkg/heat"
 	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
 	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
@@ -292,8 +293,8 @@ var _ = Describe("Heat controller", func() {
 					},
 				),
 			)
-			mariadb.SimulateMariaDBAccountCompleted(heatName)
-			mariadb.SimulateMariaDBDatabaseCompleted(heatName)
+			mariadb.SimulateMariaDBAccountCompleted(types.NamespacedName{Namespace: namespace, Name: GetHeat(heatName).Spec.DatabaseAccount})
+			mariadb.SimulateMariaDBDatabaseCompleted(types.NamespacedName{Namespace: namespace, Name: heat.DatabaseCRName})
 		})
 
 		It("should have service config ready", func() {
@@ -365,8 +366,8 @@ var _ = Describe("Heat controller", func() {
 					},
 				),
 			)
-			mariadb.SimulateMariaDBAccountCompleted(heatName)
-			mariadb.SimulateMariaDBDatabaseCompleted(heatName)
+			mariadb.SimulateMariaDBAccountCompleted(types.NamespacedName{Namespace: namespace, Name: GetHeat(heatName).Spec.DatabaseAccount})
+			mariadb.SimulateMariaDBDatabaseCompleted(types.NamespacedName{Namespace: namespace, Name: heat.DatabaseCRName})
 		})
 
 		It("should have db ready condition", func() {
@@ -422,8 +423,8 @@ var _ = Describe("Heat controller", func() {
 					},
 				),
 			)
-			mariadb.SimulateMariaDBAccountCompleted(heatName)
-			mariadb.SimulateMariaDBDatabaseCompleted(heatName)
+			mariadb.SimulateMariaDBAccountCompleted(types.NamespacedName{Namespace: namespace, Name: GetHeat(heatName).Spec.DatabaseAccount})
+			mariadb.SimulateMariaDBDatabaseCompleted(types.NamespacedName{Namespace: namespace, Name: heat.DatabaseCRName})
 			dbSyncJobName := types.NamespacedName{
 				Name:      "heat-db-sync",
 				Namespace: namespace,
@@ -461,7 +462,7 @@ var _ = Describe("Heat controller", func() {
 			harness.Setup(
 				"Heat",
 				heatName.Namespace,
-				heatName.Name,
+				heat.DatabaseName,
 				"Heat",
 				mariadb, timeout, interval,
 			)
@@ -499,7 +500,8 @@ var _ = Describe("Heat controller", func() {
 				),
 			)
 			mariadb.SimulateMariaDBAccountCompleted(accountName)
-			mariadb.SimulateMariaDBDatabaseCompleted(heatName)
+			mariadb.SimulateMariaDBDatabaseCompleted(types.NamespacedName{Namespace: namespace, Name: heat.DatabaseCRName})
+
 			dbSyncJobName := types.NamespacedName{
 				Name:      "heat-db-sync",
 				Namespace: namespace,


### PR DESCRIPTION
This change refactors the use of all GetDatabaseByName() calls to use the new GetDatabaseByNameAndAccount() helper function.

this can either supersede #339 or be merged into #339.