### PR TITLE
Change heat engine pod label

### DIFF
--- a/controllers/heatengine_controller.go
+++ b/controllers/heatengine_controller.go
@@ -442,7 +442,7 @@ func (r *HeatEngineReconciler) reconcileNormal(
 
 	serviceLabels := map[string]string{
 		common.AppSelector:       heat.ServiceName,
-		common.ComponentSelector: heat.APIComponent,
+		common.ComponentSelector: heat.EngineComponent,
 	}
 
 	// Handle service init


### PR DESCRIPTION
The label is incorrectly set to: "component: api"