### PR TITLE
Fix HeatCnfAPI ReadyCondition check

### DIFF
--- a/controllers/heatcfnapi_controller.go
+++ b/controllers/heatcfnapi_controller.go
@@ -775,6 +775,12 @@ func (r *HeatCfnAPIReconciler) reconcileNormal(ctx context.Context, instance *he
 	}
 	// create Deployment - end
 
+	// We reached the end of the Reconcile, update the Ready condition based on
+	// the sub conditions
+	if instance.Status.Conditions.AllSubConditionIsTrue() {
+		instance.Status.Conditions.MarkTrue(
+			condition.ReadyCondition, condition.ReadyMessage)
+	}
 	r.Log.Info("Reconciled CfnAPI successfully")
 	return ctrl.Result{}, nil
 }


### PR DESCRIPTION
The previous patch missed the check of `AllSubConditionIsTrue` that, has a consequence, marks the global `ReadyCondition` as `True`. This patch fixes the wrong behavior adding the missing code block.