### PR TITLE
Remove explicit status update

### DIFF
--- a/controllers/heat_controller.go
+++ b/controllers/heat_controller.go
@@ -804,9 +804,6 @@ func (r *HeatReconciler) reconcileInit(ctx context.Context,
 
 	if dbSyncjob.HasChanged() {
 		instance.Status.Hash[heatv1beta1.DbSyncHash] = dbSyncjob.GetHash()
-		if err := r.Client.Status().Update(ctx, instance); err != nil {
-			return ctrl.Result{}, err
-		}
 		r.Log.Info(fmt.Sprintf("Job %s hash added - %s", jobDef.Name, instance.Status.Hash[heatv1beta1.DbSyncHash]))
 	}
 	instance.Status.Conditions.MarkTrue(condition.DBSyncReadyCondition, condition.DBSyncReadyMessage)
@@ -1062,9 +1059,6 @@ func (r *HeatReconciler) createHashOfInputHashes(
 	}
 	if hashMap, changed := util.SetHash(instance.Status.Hash, common.InputHashName, hash); changed {
 		instance.Status.Hash = hashMap
-		if err := r.Client.Status().Update(ctx, instance); err != nil {
-			return hash, err
-		}
 		r.Log.Info(fmt.Sprintf("Input maps hash %s - %s", common.InputHashName, hash))
 	}
 	return hash, nil

--- a/controllers/heatapi_controller.go
+++ b/controllers/heatapi_controller.go
@@ -908,9 +908,6 @@ func (r *HeatAPIReconciler) createHashOfInputHashes(
 	}
 	if hashMap, changed := util.SetHash(instance.Status.Hash, common.InputHashName, hash); changed {
 		instance.Status.Hash = hashMap
-		if err := r.Client.Status().Update(ctx, instance); err != nil {
-			return hash, err
-		}
 		r.Log.Info(fmt.Sprintf("Input maps hash %s - %s", common.InputHashName, hash))
 	}
 	return hash, nil

--- a/controllers/heatcfnapi_controller.go
+++ b/controllers/heatcfnapi_controller.go
@@ -907,9 +907,6 @@ func (r *HeatCfnAPIReconciler) createHashOfInputHashes(
 	}
 	if hashMap, changed := util.SetHash(instance.Status.Hash, common.InputHashName, hash); changed {
 		instance.Status.Hash = hashMap
-		if err := r.Client.Status().Update(ctx, instance); err != nil {
-			return hash, err
-		}
 		r.Log.Info(fmt.Sprintf("Input maps hash %s - %s", common.InputHashName, hash))
 	}
 	return hash, nil

--- a/controllers/heatengine_controller.go
+++ b/controllers/heatengine_controller.go
@@ -625,9 +625,6 @@ func (r *HeatEngineReconciler) createHashOfInputHashes(
 	}
 	if hashMap, changed := util.SetHash(instance.Status.Hash, common.InputHashName, hash); changed {
 		instance.Status.Hash = hashMap
-		if err := r.Client.Status().Update(ctx, instance); err != nil {
-			return hash, err
-		}
 		r.Log.Info(fmt.Sprintf("Input maps hash %s - %s", common.InputHashName, hash))
 	}
 	return hash, nil


### PR DESCRIPTION
To make it easier to reason about when the instance is updated this
patch removes the explicit status update form the reconcile
code path and let the controller rely on the deferred PatchInstance call
as the only place where the instance is persisted.

The removed code probably didn't cause any trouble as it only updated
the status subresource and all the non status update (the self finalizer)
is guarded with an explicit return from the reconciler. So no non status
update is lost due to this status update. Still this cleanup might help
avoiding future issues.
