### PR TITLE
Enable causality checks for db operations

### DIFF
--- a/templates/heat/config/heat.conf
+++ b/templates/heat/config/heat.conf
@@ -21,6 +21,9 @@ tls_enabled={{ .MemcachedTLS }}
 connection={{ .DatabaseConnection }}
 max_retries=-1
 db_max_retries=-1
+# Enable causality checks on read operations
+mysql_wsrep_sync_wait = 1
+
 
 [ec2authtoken]
 auth_uri={{ .KeystoneInternalURL }}/v3/ec2tokens


### PR DESCRIPTION
Enable causality checks for read operations to avoid random db issues like Deadlock and IntegrityError as we're using multi-master galera cluster.