### PR TITLE
Add default for DatabaseInstance

### DIFF
--- a/api/bases/heat.openstack.org_heats.yaml
+++ b/api/bases/heat.openstack.org_heats.yaml
@@ -57,6 +57,7 @@ spec:
                   DB, defaults to heat.
                 type: string
               databaseInstance:
+                default: openstack
                 description: MariaDB instance name. Right now required by the maridb-operator
                   to get the credentials from the instance to create the DB. Might
                   not be required in future.

--- a/api/v1beta1/heat_types.go
+++ b/api/v1beta1/heat_types.go
@@ -77,6 +77,7 @@ type HeatSpecCore struct {
 // HeatSpec defines the desired state of Heat
 type HeatSpecBase struct {
 	// +kubebuilder:validation:Required
+	// +kubebuilder:default=openstack
 	// MariaDB instance name.
 	// Right now required by the maridb-operator to get the credentials from the instance to create the DB.
 	// Might not be required in future.

--- a/config/crd/bases/heat.openstack.org_heats.yaml
+++ b/config/crd/bases/heat.openstack.org_heats.yaml
@@ -57,6 +57,7 @@ spec:
                   DB, defaults to heat.
                 type: string
               databaseInstance:
+                default: openstack
                 description: MariaDB instance name. Right now required by the maridb-operator
                   to get the credentials from the instance to create the DB. Might
                   not be required in future.


### PR DESCRIPTION
Else it would be initialized to empty string when created with empty template and then webhook would not allow it to be modified.