### PR TITLE
Enable Secure RBAC

### DIFF
--- a/templates/heat/config/heat.conf
+++ b/templates/heat/config/heat.conf
@@ -34,6 +34,10 @@ driver=noop
 [oslo_middleware]
 enable_proxy_headers_parsing=True
 
+[oslo_policy]
+enforce_scope=True
+enforce_new_defaults=True
+
 [trustee]
 auth_type=password
 auth_url={{ .KeystoneInternalURL }}


### PR DESCRIPTION
This patch enables Secure RBAC to use Keystone default roles and Keystone scoped tokens.