### PR TITLE
Set heat_metadata_server_url

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1
+	github.com/openshift/api v3.9.0+incompatible
 	github.com/openstack-k8s-operators/heat-operator/api v0.3.1-0.20240214134649-6643d1b09d49
 	github.com/openstack-k8s-operators/infra-operator/apis v0.3.1-0.20240604144138-996e41d1af19
 	github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240605055850-8ee0ece70906
@@ -51,7 +52,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/openshift/api v3.9.0+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.18.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	routev1 "github.com/openshift/api/route/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -60,6 +61,7 @@ func init() {
 	utilruntime.Must(mariadbv1beta1.AddToScheme(scheme))
 	utilruntime.Must(memcachedv1.AddToScheme(scheme))
 	utilruntime.Must(rabbitmqv1.AddToScheme(scheme))
+	utilruntime.Must(routev1.AddToScheme(scheme))
 	err := keystonev1beta1.AddToScheme(scheme)
 	if err != nil {
 		setupLog.Info("Adding keystone schema failed, only standalone deployments are available")

--- a/templates/heat/config/heat.conf
+++ b/templates/heat/config/heat.conf
@@ -7,6 +7,10 @@ num_engine_workers=4
 #auth_encryption_key =
 use_stderr=true
 
+{% if .HeatMetadataServerUrl != "" %}
+heat_metadata_server_url = {{.HeatMetadataServerUrl}}
+{% endif %}
+
 [cache]
 {{if .MemcachedTLS}}
 backend = dogpile.cache.pymemcache

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -94,3 +94,29 @@ func HeatConditionGetter(name types.NamespacedName) condition.Conditions {
 	instance := GetHeat(name)
 	return instance.Status.Conditions
 }
+
+func CreateHeatCFNRoute(name types.NamespacedName) client.Object {
+
+	raw := map[string]interface{}{
+		"apiVersion": "route.openshift.io/v1",
+		"kind":       "Route",
+		"metadata": map[string]interface{}{
+			"name":      name.Name,
+			"namespace": name.Namespace,
+		},
+		"spec": map[string]interface{}{
+			"host": "heat-cfnapi-public.host.test",
+			"port": map[string]interface{}{
+				"targetPort": "heat-cfnapi-public",
+			},
+			"to": map[string]interface{}{
+				"kind":           "Service",
+				"name":           "heat-cfnapi-public",
+				"weight":         100,
+				"wildcardPolicy": "None",
+			},
+		},
+	}
+
+	return th.CreateUnstructured(raw)
+}

--- a/tests/functional/heat_controller_test.go
+++ b/tests/functional/heat_controller_test.go
@@ -46,6 +46,7 @@ var _ = Describe("Heat controller", func() {
 	var heatConfigSecretName types.NamespacedName
 	var memcachedSpec memcachedv1.MemcachedSpec
 	var keystoneAPI *keystonev1.KeystoneAPI
+	var heatCfnAPIRouteName types.NamespacedName
 
 	BeforeEach(func() {
 
@@ -66,9 +67,14 @@ var _ = Describe("Heat controller", func() {
 				Replicas: ptr.To[int32](3),
 			},
 		}
+		heatCfnAPIRouteName = types.NamespacedName{
+			Namespace: namespace,
+			Name:      heatName.Name + "-cfnapi-public",
+		}
 
 		err := os.Setenv("OPERATOR_TEMPLATES", "../../templates")
 		Expect(err).NotTo(HaveOccurred())
+		CreateHeatCFNRoute(heatCfnAPIRouteName)
 	})
 
 	When("A Heat instance is created", func() {

--- a/tests/functional/openshift_crds/route/v1/route_crd.yml
+++ b/tests/functional/openshift_crds/route/v1/route_crd.yml
@@ -1,0 +1,176 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  # name must be in the form: <plural>.<group>
+  # <group> has to match the correspondig .spec field
+  name: routes.route.openshift.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: route.openshift.io
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      "schema":
+        "openAPIV3Schema":
+          description: "A route allows developers to expose services through an HTTP(S) aware load balancing and proxy layer via a public DNS entry. The route may further specify TLS options and a certificate, or specify a public CNAME that the router should also accept for HTTP and HTTPS traffic. An administrator typically configures their router to be visible outside the cluster firewall, and may also add additional security, caching, or traffic controls on the service content. Routers usually talk directly to the service endpoints. \n Once a route is created, the `host` field may not be changed. Generally, routers use the oldest route with a given host when resolving conflicts. \n Routers are subject to additional customization and may support additional controls via the annotations field. \n Because administrators may configure multiple routers, the route status field is used to return information to clients about the names and states of the route under each router. If a client chooses a duplicate name, for instance, the route status conditions are used to indicate the route cannot be chosen. \n To enable HTTP/2 ALPN on a route it requires a custom (non-wildcard) certificate. This prevents connection coalescing by clients, notably web browsers. We do not support HTTP/2 ALPN on routes that use the default certificate because of the risk of connection re-use/coalescing. Routes that do not have their own custom certificate will not be HTTP/2 ALPN-enabled on either the frontend or the backend. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec is the desired state of the route
+              type: object
+              required:
+                - to
+              properties:
+                alternateBackends:
+                  description: alternateBackends allows up to 3 additional backends to be assigned to the route. Only the Service kind is allowed, and it will be defaulted to Service. Use the weight field in RouteTargetReference object to specify relative preference.
+                  type: array
+                  items:
+                    description: RouteTargetReference specifies the target that resolve into endpoints. Only the 'Service' kind is allowed. Use 'weight' field to emphasize one over others.
+                    type: object
+                    required:
+                      - kind
+                      - name
+                    properties:
+                      kind:
+                        description: The kind of target that the route is referring to. Currently, only 'Service' is allowed
+                        type: string
+                      name:
+                        description: name of the service/target that is being referred to. e.g. name of the service
+                        type: string
+                      weight:
+                        description: weight as an integer between 0 and 256, default 100, that specifies the target's relative weight against other target reference objects. 0 suppresses requests to this backend.
+                        type: integer
+                        format: int32
+                host:
+                  description: host is an alias/DNS that points to the service. Optional. If not specified a route name will typically be automatically chosen. Must follow DNS952 subdomain conventions.
+                  type: string
+                path:
+                  description: path that the router watches for, to route traffic for to the service. Optional
+                  type: string
+                port:
+                  description: If specified, the port to be used by the router. Most routers will use all endpoints exposed by the service by default - set this value to instruct routers which port to use.
+                  type: object
+                  required:
+                    - targetPort
+                  properties:
+                    targetPort:
+                      description: The target port on pods selected by the service this route points to. If this is a string, it will be looked up as a named port in the target endpoints port list. Required
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      x-kubernetes-int-or-string: true
+                subdomain:
+                  description: "subdomain is a DNS subdomain that is requested within the ingress controller's domain (as a subdomain). If host is set this field is ignored. An ingress controller may choose to ignore this suggested name, in which case the controller will report the assigned name in the status.ingress array or refuse to admit the route. If this value is set and the server does not support this field host will be populated automatically. Otherwise host is left empty. The field may have multiple parts separated by a dot, but not all ingress controllers may honor the request. This field may not be changed after creation except by a user with the update routes/custom-host permission. \n Example: subdomain `frontend` automatically receives the router subdomain `apps.mycluster.com` to have a full hostname `frontend.apps.mycluster.com`."
+                  type: string
+                tls:
+                  description: The tls field provides the ability to configure certificates and termination for the route.
+                  type: object
+                  required:
+                    - termination
+                  properties:
+                    caCertificate:
+                      description: caCertificate provides the cert authority certificate contents
+                      type: string
+                    certificate:
+                      description: certificate provides certificate contents. This should be a single serving certificate, not a certificate chain. Do not include a CA certificate.
+                      type: string
+                    destinationCACertificate:
+                      description: destinationCACertificate provides the contents of the ca certificate of the final destination.  When using reencrypt termination this file should be provided in order to have routers use it for health checks on the secure connection. If this field is not specified, the router may provide its own destination CA and perform hostname validation using the short service name (service.namespace.svc), which allows infrastructure generated certificates to automatically verify.
+                      type: string
+                    insecureEdgeTerminationPolicy:
+                      description: "insecureEdgeTerminationPolicy indicates the desired behavior for insecure connections to a route. While each router may make its own decisions on which ports to expose, this is normally port 80. \n * Allow - traffic is sent to the server on the insecure port (default) * Disable - no traffic is allowed on the insecure port. * Redirect - clients are redirected to the secure port."
+                      type: string
+                    key:
+                      description: key provides key file contents
+                      type: string
+                    termination:
+                      description: "termination indicates termination type. \n * edge - TLS termination is done by the router and http is used to communicate with the backend (default) * passthrough - Traffic is sent straight to the destination without the router providing TLS termination * reencrypt - TLS termination is done by the router and https is used to communicate with the backend"
+                      type: string
+                to:
+                  description: to is an object the route should use as the primary backend. Only the Service kind is allowed, and it will be defaulted to Service. If the weight field (0-256 default 100) is set to zero, no traffic will be sent to this backend.
+                  type: object
+                  required:
+                    - kind
+                    - name
+                  properties:
+                    kind:
+                      description: The kind of target that the route is referring to. Currently, only 'Service' is allowed
+                      type: string
+                    name:
+                      description: name of the service/target that is being referred to. e.g. name of the service
+                      type: string
+                    weight:
+                      description: weight as an integer between 0 and 256, default 100, that specifies the target's relative weight against other target reference objects. 0 suppresses requests to this backend.
+                      type: integer
+                      format: int32
+                wildcardPolicy:
+                  description: Wildcard policy if any for the route. Currently only 'Subdomain' or 'None' is allowed.
+                  type: string
+            status:
+              description: status is the current state of the route
+              type: object
+              properties:
+                ingress:
+                  description: ingress describes the places where the route may be exposed. The list of ingress points may contain duplicate Host or RouterName values. Routes are considered live once they are `Ready`
+                  type: array
+                  items:
+                    description: RouteIngress holds information about the places where a route is exposed.
+                    type: object
+                    properties:
+                      conditions:
+                        description: Conditions is the state of the route, may be empty.
+                        type: array
+                        items:
+                          description: RouteIngressCondition contains details for the current condition of this route on a particular router.
+                          type: object
+                          required:
+                            - status
+                            - type
+                          properties:
+                            lastTransitionTime:
+                              description: RFC 3339 date and time when this condition last transitioned
+                              type: string
+                              format: date-time
+                            message:
+                              description: Human readable message indicating details about last transition.
+                              type: string
+                            reason:
+                              description: (brief) reason for the condition's last transition, and is usually a machine and human readable constant
+                              type: string
+                            status:
+                              description: Status is the status of the condition. Can be True, False, Unknown.
+                              type: string
+                            type:
+                              description: Type is the type of the condition. Currently only Admitted.
+                              type: string
+                      host:
+                        description: Host is the host string under which the route is exposed; this value is required
+                        type: string
+                      routerCanonicalHostname:
+                        description: CanonicalHostname is the external host name for the router that can be used as a CNAME for the host requested for this route. This value is optional and may not be set in all cases.
+                        type: string
+                      routerName:
+                        description: Name is a name chosen by the router to identify itself; this value is required
+                        type: string
+                      wildcardPolicy:
+                        description: Wildcard policy is the wildcard policy that was allowed where this route is exposed.
+                        type: string
+  scope: Namespaced
+  subresources:
+    # enable spec/status
+    status: {}
+  names:
+    plural: routes
+    singular: route
+    kind: Route

--- a/tests/functional/suite_test.go
+++ b/tests/functional/suite_test.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
 	. "github.com/onsi/gomega"    //revive:disable:dot-imports
 
+	routev1 "github.com/openshift/api/route/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -91,6 +92,7 @@ var _ = BeforeSuite(func() {
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{
 			filepath.Join("..", "..", "config", "crd", "bases"),
+			filepath.Join("openshift_crds", "route", "v1"),
 			keystoneCRDs,
 			mariaDBCRDs,
 			infraCRDs,
@@ -119,6 +121,8 @@ var _ = BeforeSuite(func() {
 	err = memcachedv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 	err = rabbitmqv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+	err = routev1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	//+kubebuilder:scaffold:scheme


### PR DESCRIPTION
This change adds the capability to detect and set the cfn route as the heat_metadata_server_url in the heat.conf file