### PR TITLE
Add waitcondition server url

### DIFF
--- a/controllers/heat_controller.go
+++ b/controllers/heat_controller.go
@@ -714,6 +714,7 @@ func (r *HeatReconciler) reconcileNormal(ctx context.Context, instance *heatv1be
 			err.Error()))
 		return ctrl.Result{}, err
 	}
+
 	// Check the observed Generation and mirror the condition from the
 	// underlying resource reconciliation
 	cfnObsGen, err := r.checkHeatCfnGeneration(instance)
@@ -961,6 +962,11 @@ func (r *HeatReconciler) generateServiceConfigMaps(
 		return err
 	}
 
+	var heatCfnAPIRoute string
+	if _, ok := instance.Spec.HeatCfnAPI.Override.Service["public"]; ok {
+		heatCfnAPIRoute = *instance.Spec.HeatCfnAPI.Override.Service["public"].EndpointURL
+	}
+
 	databaseAccount := db.GetAccount()
 	dbSecret := db.GetSecret()
 
@@ -978,6 +984,7 @@ func (r *HeatReconciler) generateServiceConfigMaps(
 			instance.Status.DatabaseHostname,
 			heat.DatabaseName,
 		),
+		"HeatMetadataServerUrl": heatCfnAPIRoute,
 	}
 
 	// create HeatAPI httpd vhost template parameters

--- a/controllers/heat_controller.go
+++ b/controllers/heat_controller.go
@@ -970,11 +970,6 @@ func (r *HeatReconciler) generateServiceConfigMaps(
 	databaseAccount := db.GetAccount()
 	dbSecret := db.GetSecret()
 
-	heatCfnAPIRoute, err := r.getHeatCfnAPIRoute(instance)
-	if err != nil {
-		return err
-	}
-
 	templateParameters := map[string]interface{}{
 		"KeystoneInternalURL":      authURL,
 		"ServiceUser":              instance.Spec.ServiceUser,

--- a/controllers/heat_controller.go
+++ b/controllers/heat_controller.go
@@ -989,7 +989,8 @@ func (r *HeatReconciler) generateServiceConfigMaps(
 			instance.Status.DatabaseHostname,
 			heat.DatabaseName,
 		),
-		"HeatMetadataServerUrl": heatCfnAPIRoute,
+		"HeatMetadataServerUrl":      heatCfnAPIRoute,
+		"HeatWaitConditionServerUrl": heatCfnAPIRoute,
 	}
 
 	// create HeatAPI httpd vhost template parameters

--- a/controllers/heat_controller.go
+++ b/controllers/heat_controller.go
@@ -970,7 +970,7 @@ func (r *HeatReconciler) generateServiceConfigMaps(
 	databaseAccount := db.GetAccount()
 	dbSecret := db.GetSecret()
 
-	heatCfnAPIRoute, err := r.getHeatCFNAPIRoute(instance)
+	heatCfnAPIRoute, err := r.getHeatCfnAPIRoute(instance)
 	if err != nil {
 		return err
 	}

--- a/controllers/heat_controller.go
+++ b/controllers/heat_controller.go
@@ -970,6 +970,11 @@ func (r *HeatReconciler) generateServiceConfigMaps(
 	databaseAccount := db.GetAccount()
 	dbSecret := db.GetSecret()
 
+	heatCfnAPIRoute, err := r.getHeatCFNAPIRoute(instance)
+	if err != nil {
+		return err
+	}
+
 	templateParameters := map[string]interface{}{
 		"KeystoneInternalURL":      authURL,
 		"ServiceUser":              instance.Spec.ServiceUser,

--- a/templates/heat/config/heat.conf
+++ b/templates/heat/config/heat.conf
@@ -8,6 +8,7 @@ num_engine_workers=4
 use_stderr=true
 {{ if ne .HeatMetadataServerUrl "" }}
 heat_metadata_server_url={{.HeatMetadataServerUrl}}
+heat_waitcondition_server_url={{.HeatWaitConditionServerUrl}}/v1/waitcondition
 {{ end }}
 
 [cache]

--- a/templates/heat/config/heat.conf
+++ b/templates/heat/config/heat.conf
@@ -7,7 +7,7 @@ num_engine_workers=4
 #auth_encryption_key =
 use_stderr=true
 {{ if ne .HeatMetadataServerUrl "" }}
-heat_metadata_server_url = {{.HeatMetadataServerUrl}}
+heat_metadata_server_url={{.HeatMetadataServerUrl}}
 {{ end }}
 
 [cache]

--- a/templates/heat/config/heat.conf
+++ b/templates/heat/config/heat.conf
@@ -6,6 +6,9 @@ stack_domain_admin={{ .StackDomainAdminUsername }}
 num_engine_workers=4
 #auth_encryption_key =
 use_stderr=true
+{{ if ne .HeatMetadataServerUrl "" }}
+heat_metadata_server_url = {{.HeatMetadataServerUrl}}
+{{ end }}
 
 [cache]
 {{if .MemcachedTLS}}

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -33,7 +33,7 @@ func GetDefaultHeatSpec() map[string]interface{} {
 		"secret":           SecretName,
 		"heatEngine":       GetDefaultHeatEngineSpec(),
 		"heatAPI":          GetDefaultHeatAPISpec(),
-		"heatCfnAPI":       GetDefaultHeatCFNAPISpec(),
+		"heatCfnAPI":       GetDefaultHeatCfnAPISpec(),
 	}
 }
 
@@ -45,8 +45,29 @@ func GetDefaultHeatEngineSpec() map[string]interface{} {
 	return map[string]interface{}{}
 }
 
-func GetDefaultHeatCFNAPISpec() map[string]interface{} {
-	return map[string]interface{}{}
+func GetDefaultHeatCfnAPISpec() map[string]interface{} {
+
+	serviceOverride := map[string]interface{}{}
+	serviceOverride["public"] = map[string]interface{}{
+		"endpointURL": "https://heat-cfnapi-public-openstack.test",
+		"metadata": map[string]map[string]string{
+			"labels": {
+				"osctlplane":         "",
+				"osctlplane-service": "heat-cfn",
+			},
+		},
+	}
+	return map[string]interface{}{
+		"databaseHostname":   "openstack",
+		"secret":             SecretName,
+		"containerImage":     "quay.io/podified-antelope-centos9/openstack-heat-api-cfn:current-podified",
+		"serviceAccount":     "heat",
+		"transportURLSecret": "rabbitmq-secret",
+
+		"override": map[string]interface{}{
+			"service": serviceOverride,
+		},
+	}
 }
 
 func CreateHeat(name types.NamespacedName, spec map[string]interface{}) client.Object {
@@ -63,8 +84,42 @@ func CreateHeat(name types.NamespacedName, spec map[string]interface{}) client.O
 	return th.CreateUnstructured(raw)
 }
 
+func CreateHeatCfnAPI(name types.NamespacedName, spec map[string]interface{}) client.Object {
+
+	parent := GetHeat(types.NamespacedName{Namespace: namespace, Name: "heat"})
+	raw := map[string]interface{}{
+		"apiVersion": "heat.openstack.org/v1beta1",
+		"kind":       "HeatCfnAPI",
+		"metadata": map[string]interface{}{
+			"name":      name.Name,
+			"namespace": name.Namespace,
+			"ownerReferences": []map[string]interface{}{
+				{
+					"apiVersion":         "heat.openstack.org/v1beta1",
+					"blockOwnerDeletion": true,
+					"controller":         true,
+					"kind":               "Heat",
+					"name":               parent.GetObjectMeta().GetName(),
+					"uid":                parent.GetObjectMeta().GetUID(),
+				},
+			},
+		},
+		"spec": spec,
+	}
+	return th.CreateUnstructured(raw)
+
+}
+
 func GetHeat(name types.NamespacedName) *heatv1.Heat {
 	instance := &heatv1.Heat{}
+	Eventually(func(g Gomega) {
+		g.Expect(k8sClient.Get(ctx, name, instance)).Should(Succeed())
+	}, timeout, interval).Should(Succeed())
+	return instance
+}
+
+func GetHeatCfnAPI(name types.NamespacedName) *heatv1.HeatCfnAPI {
+	instance := &heatv1.HeatCfnAPI{}
 	Eventually(func(g Gomega) {
 		g.Expect(k8sClient.Get(ctx, name, instance)).Should(Succeed())
 	}, timeout, interval).Should(Succeed())

--- a/tests/functional/heat_controller_test.go
+++ b/tests/functional/heat_controller_test.go
@@ -341,6 +341,8 @@ var _ = Describe("Heat controller", func() {
 				ContainSubstring("auth_url=%s", keystoneAPI.Status.APIEndpoints["internal"]))
 			Eventually(heatCfg).Should(
 				ContainSubstring("heat_metadata_server_url=%s", "https://heat-cfnapi-public-openstack.test"))
+			Eventually(heatCfg).Should(
+				ContainSubstring("heat_waitcondition_server_url=%s", "https://heat-cfnapi-public-openstack.test/v1/waitcondition"))
 			Expect(heatCfg).Should(
 				ContainSubstring("www_authenticate_uri=http://keystone-internal.openstack.svc"))
 			Expect(heatCfg).Should(

--- a/tests/functional/suite_test.go
+++ b/tests/functional/suite_test.go
@@ -184,6 +184,14 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
+	err = (&controllers.HeatCfnAPIReconciler{
+		Client:  k8sManager.GetClient(),
+		Scheme:  k8sManager.GetScheme(),
+		Kclient: kclient,
+		Log:     ctrl.Log.WithName("controllers").WithName("HeatCfnAPI"),
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
 	go func() {
 		defer GinkgoRecover()
 		err = k8sManager.Start(ctx)


### PR DESCRIPTION
This change adds the `heat_waitcondition_server_url` parameter to the `heat.conf` file and is consistent with how TripleO was configuring the service:
https://github.com/openstack-archive/tripleo-heat-templates/blob/stable/wallaby/deployment/heat/heat-engine-container-puppet.yaml#L179-L184