### PR TITLE
Implement cluster logging

### DIFF
--- a/controllers/heat_controller.go
+++ b/controllers/heat_controller.go
@@ -42,6 +42,7 @@ import (
 	heat "github.com/openstack-k8s-operators/heat-operator/pkg/heat"
 	heatapi "github.com/openstack-k8s-operators/heat-operator/pkg/heatapi"
 	heatcfnapi "github.com/openstack-k8s-operators/heat-operator/pkg/heatcfnapi"
+	heatengine "github.com/openstack-k8s-operators/heat-operator/pkg/heatengine"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
 	labels "github.com/openstack-k8s-operators/lib-common/modules/common/labels"
 	common_rbac "github.com/openstack-k8s-operators/lib-common/modules/common/rbac"
@@ -972,6 +973,7 @@ func (r *HeatReconciler) generateServiceConfigMaps(
 		"MemcachedServers":         mc.GetMemcachedServerListString(),
 		"MemcachedServersWithInet": mc.GetMemcachedServerListWithInetString(),
 		"MemcachedTLS":             mc.GetMemcachedTLSSupport(),
+		"LogFile":                  heatengine.HeatEngineLogFile,
 		"DatabaseConnection": fmt.Sprintf("mysql+pymysql://%s:%s@%s/%s?read_default_file=/etc/my.cnf",
 			databaseAccount.Spec.UserName,
 			string(dbSecret.Data[mariadbv1.DatabasePasswordSelector]),

--- a/controllers/heat_controller.go
+++ b/controllers/heat_controller.go
@@ -996,6 +996,10 @@ func (r *HeatReconciler) generateServiceConfigMaps(
 		httpdVhostConfig[endpt.String()] = endptConfig
 	}
 	templateParameters["APIvHosts"] = httpdVhostConfig
+	templateParameters["APIGlobal"] = map[string]interface{}{
+		"APILogFile":      heatapi.HeatAPILogFile,
+		"APIErrorLogFile": heatapi.HeatAPIErrorLogFile,
+	}
 
 	// create HeatCfnAPI httpd vhost template parameters
 	httpdVhostConfig = map[string]interface{}{}

--- a/pkg/heat/volumes.go
+++ b/pkg/heat/volumes.go
@@ -49,6 +49,18 @@ func GetVolumes(name string) []corev1.Volume {
 				EmptyDir: &corev1.EmptyDirVolumeSource{Medium: ""},
 			},
 		},
+		{
+			Name: "heat-logs",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{Medium: ""},
+			},
+		},
+		{
+			Name: "httpd-logs",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{Medium: ""},
+			},
+		},
 	}
 }
 
@@ -76,8 +88,12 @@ func GetInitVolumeMounts() []corev1.VolumeMount {
 			SubPath:   "my.cnf",
 			ReadOnly:  true,
 		},
+		{
+			Name:      "heat-logs",
+			MountPath: "/var/log/heat",
+			ReadOnly:  false,
+		},
 	}
-
 }
 
 // GetVolumeMounts ...
@@ -98,6 +114,16 @@ func GetVolumeMounts() []corev1.VolumeMount {
 			MountPath: "/etc/my.cnf",
 			SubPath:   "my.cnf",
 			ReadOnly:  true,
+		},
+		{
+			Name:      "heat-logs",
+			MountPath: "/var/log/heat",
+			ReadOnly:  false,
+		},
+		{
+			Name:      "httpd-logs",
+			MountPath: "/var/log/httpd",
+			ReadOnly:  false,
 		},
 	}
 }

--- a/pkg/heatapi/const.go
+++ b/pkg/heatapi/const.go
@@ -21,4 +21,10 @@ const (
 
 	// ServiceName -
 	ServiceName = "heat-api"
+
+	// HeatAPILogFile -
+	HeatAPILogFile = "/var/log/httpd/heat-api"
+
+	// HeatAPIErrorLogFile -
+	HeatAPIErrorLogFile = "/var/log/httpd/heat-api-error"
 )

--- a/pkg/heatapi/deployment.go
+++ b/pkg/heatapi/deployment.go
@@ -129,6 +129,25 @@ func Deployment(
 					ServiceAccountName: instance.Spec.ServiceAccount,
 					Containers: []corev1.Container{
 						{
+							Name: instance.Name + "-logs",
+							Command: []string{
+								"/bin/bash",
+							},
+							Args: []string{
+								"-c",
+								"find /var/log/httpd -type f -exec tail -n+1 -F {} +",
+							},
+							Image: instance.Spec.ContainerImage,
+							SecurityContext: &corev1.SecurityContext{
+								RunAsUser: &runAsUser,
+							},
+							Env:            env.MergeEnvs([]corev1.EnvVar{}, envVars),
+							VolumeMounts:   volumeMounts,
+							Resources:      instance.Spec.Resources,
+							ReadinessProbe: readinessProbe,
+							LivenessProbe:  livenessProbe,
+						},
+						{
 							Name: heat.ServiceName + "-" + heat.APIComponent,
 							Command: []string{
 								"/bin/bash",

--- a/pkg/heatcfnapi/deployment.go
+++ b/pkg/heatcfnapi/deployment.go
@@ -129,6 +129,25 @@ func Deployment(
 					ServiceAccountName: instance.Spec.ServiceAccount,
 					Containers: []corev1.Container{
 						{
+							Name: instance.Name + "-logs",
+							Command: []string{
+								"/bin/bash",
+							},
+							Args: []string{
+								"-c",
+								"find /var/log/httpd -type f -exec tail -n+1 -F {} +",
+							},
+							Image: instance.Spec.ContainerImage,
+							SecurityContext: &corev1.SecurityContext{
+								RunAsUser: &runAsUser,
+							},
+							Env:            env.MergeEnvs([]corev1.EnvVar{}, envVars),
+							VolumeMounts:   volumeMounts,
+							Resources:      instance.Spec.Resources,
+							ReadinessProbe: readinessProbe,
+							LivenessProbe:  livenessProbe,
+						},
+						{
 							Name: heat.ServiceName + "-" + heat.CfnAPIComponent,
 							Command: []string{
 								"/bin/bash",

--- a/pkg/heatengine/const.go
+++ b/pkg/heatengine/const.go
@@ -18,4 +18,7 @@ package heatengine
 const (
 	// KollaConfig -
 	KollaConfig = "/var/lib/config-data/merged/heat-engine-config.json"
+
+	// HeatEngineLogFile -
+	HeatEngineLogFile = "/var/log/heat/heat-engine.log"
 )

--- a/pkg/heatengine/deployment.go
+++ b/pkg/heatengine/deployment.go
@@ -99,6 +99,27 @@ func Deployment(instance *heatv1beta1.HeatEngine, configHash string, labels map[
 					ServiceAccountName: instance.Spec.ServiceAccount,
 					Containers: []corev1.Container{
 						{
+							Name: instance.Name + "-log",
+							Command: []string{
+								"/usr/bin/dumb-init",
+							},
+							Args: []string{
+								"--single-child",
+								"--",
+								"/usr/bin/tail",
+								"-n+1",
+								"-F",
+								fmt.Sprint(HeatEngineLogFile),
+							},
+							Image: instance.Spec.ContainerImage,
+							SecurityContext: &corev1.SecurityContext{
+								RunAsUser: &runAsUser,
+							},
+							Env:          env.MergeEnvs([]corev1.EnvVar{}, envVars),
+							VolumeMounts: volumeMounts,
+							Resources:    instance.Spec.Resources,
+						},
+						{
 							Name: fmt.Sprintf("%s-%s", heat.ServiceName, heat.EngineComponent),
 							Command: []string{
 								"/bin/bash",

--- a/templates/heat/config/heat-api-httpd.conf
+++ b/templates/heat/config/heat-api-httpd.conf
@@ -17,8 +17,9 @@ LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combine
 LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" proxy
 
 SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
-CustomLog /dev/stdout combined env=!forwarded
-CustomLog /dev/stdout proxy env=forwarded
+ErrorLog "{{ .APIGlobal.APIErrorLogFile }}.log"
+CustomLog "{{ .APIGlobal.APILogFile }}.log" combined env=!forwarded
+CustomLog "{{ .APIGlobal.APILogFile }}.log" proxy env=forwarded
 
 {{ range $endpt, $vhost := .APIvHosts }}
 # {{ $endpt }} vhost {{ $vhost.ServerName }} configuration
@@ -29,11 +30,8 @@ CustomLog /dev/stdout proxy env=forwarded
 
   ## Logging
   LogLevel debug
-  ErrorLog /dev/stdout
   ServerSignature Off
   SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
-  CustomLog /dev/stdout combined env=!forwarded
-  CustomLog /dev/stdout proxy env=forwarded
 
 {{- if $vhost.TLS }}
   SetEnvIf X-Forwarded-Proto https HTTPS=1

--- a/templates/heat/config/heat.conf
+++ b/templates/heat/config/heat.conf
@@ -6,6 +6,7 @@ stack_domain_admin={{ .StackDomainAdminUsername }}
 num_engine_workers=4
 #auth_encryption_key =
 use_stderr=true
+log_file={{.LogFile}}
 
 [cache]
 {{if .MemcachedTLS}}

--- a/tests/kuttl/tests/heat_tls/01-assert.yaml
+++ b/tests/kuttl/tests/heat_tls/01-assert.yaml
@@ -88,6 +88,51 @@ spec:
       containers:
       - args:
         - -c
+        - find /var/log/httpd -type f -exec tail -n+1 -F {} +
+        command:
+        - /bin/bash
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+        - mountPath: /usr/local/bin/container-scripts
+          name: scripts
+          readOnly: true
+        - mountPath: /var/lib/config-data/merged
+          name: config-data-merged
+        - mountPath: /etc/my.cnf
+          name: config-data
+          readOnly: true
+          subPath: my.cnf
+        - mountPath: /var/log/heat
+          name: heat-logs
+        - mountPath: /var/log/httpd
+          name: httpd-logs
+        - mountPath: /var/lib/kolla/config_files/config.json
+          name: config-data-merged
+          readOnly: true
+          subPath: heat-api-config.json
+        - mountPath: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+          name: combined-ca-bundle
+          readOnly: true
+          subPath: tls-ca-bundle.pem
+        - mountPath: /var/lib/config-data/tls/certs/internal.crt
+          name: internal-tls-certs
+          readOnly: true
+          subPath: tls.crt
+        - mountPath: /var/lib/config-data/tls/private/internal.key
+          name: internal-tls-certs
+          readOnly: true
+          subPath: tls.key
+        - mountPath: /var/lib/config-data/tls/certs/public.crt
+          name: public-tls-certs
+          readOnly: true
+          subPath: tls.crt
+        - mountPath: /var/lib/config-data/tls/private/public.key
+          name: public-tls-certs
+          readOnly: true
+          subPath: tls.key
+      - args:
+        - -c
         - /usr/local/bin/kolla_httpd_setup && /usr/local/bin/kolla_start
         volumeMounts:
         - mountPath: /usr/local/bin/container-scripts
@@ -99,6 +144,10 @@ spec:
           name: config-data
           readOnly: true
           subPath: my.cnf
+        - mountPath: /var/log/heat
+          name: heat-logs
+        - mountPath: /var/log/httpd
+          name: httpd-logs
         - mountPath: /var/lib/kolla/config_files/config.json
           name: config-data-merged
           readOnly: true
@@ -139,6 +188,8 @@ spec:
           name: config-data
           readOnly: true
           subPath: my.cnf
+        - mountPath: /var/log/heat
+          name: heat-logs
         - mountPath: /var/lib/config-data/custom
           name: config-data-custom
           readOnly: true
@@ -157,6 +208,10 @@ spec:
           secretName: heat-config-data
       - emptyDir: {}
         name: config-data-merged
+      - emptyDir: {}
+        name: heat-logs
+      - emptyDir: {}
+        name: httpd-logs
       - name: config-data-custom
         secret:
           defaultMode: 416
@@ -185,6 +240,51 @@ spec:
       containers:
       - args:
         - -c
+        - find /var/log/httpd -type f -exec tail -n+1 -F {} +
+        command:
+        - /bin/bash
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+        - mountPath: /usr/local/bin/container-scripts
+          name: scripts
+          readOnly: true
+        - mountPath: /var/lib/config-data/merged
+          name: config-data-merged
+        - mountPath: /etc/my.cnf
+          name: config-data
+          readOnly: true
+          subPath: my.cnf
+        - mountPath: /var/log/heat
+          name: heat-logs
+        - mountPath: /var/log/httpd
+          name: httpd-logs
+        - mountPath: /var/lib/kolla/config_files/config.json
+          name: config-data-merged
+          readOnly: true
+          subPath: heat-cfnapi-config.json
+        - mountPath: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+          name: combined-ca-bundle
+          readOnly: true
+          subPath: tls-ca-bundle.pem
+        - mountPath: /var/lib/config-data/tls/certs/internal.crt
+          name: internal-tls-certs
+          readOnly: true
+          subPath: tls.crt
+        - mountPath: /var/lib/config-data/tls/private/internal.key
+          name: internal-tls-certs
+          readOnly: true
+          subPath: tls.key
+        - mountPath: /var/lib/config-data/tls/certs/public.crt
+          name: public-tls-certs
+          readOnly: true
+          subPath: tls.crt
+        - mountPath: /var/lib/config-data/tls/private/public.key
+          name: public-tls-certs
+          readOnly: true
+          subPath: tls.key
+      - args:
+        - -c
         - /usr/local/bin/kolla_httpd_setup && /usr/local/bin/kolla_start
         volumeMounts:
         - mountPath: /usr/local/bin/container-scripts
@@ -196,6 +296,10 @@ spec:
           name: config-data
           readOnly: true
           subPath: my.cnf
+        - mountPath: /var/log/heat
+          name: heat-logs
+        - mountPath: /var/log/httpd
+          name: httpd-logs
         - mountPath: /var/lib/kolla/config_files/config.json
           name: config-data-merged
           readOnly: true
@@ -236,6 +340,8 @@ spec:
           name: config-data
           readOnly: true
           subPath: my.cnf
+        - mountPath: /var/log/heat
+          name: heat-logs
         - mountPath: /var/lib/config-data/custom
           name: config-data-custom
           readOnly: true
@@ -254,6 +360,10 @@ spec:
           secretName: heat-config-data
       - emptyDir: {}
         name: config-data-merged
+      - emptyDir: {}
+        name: heat-logs
+      - emptyDir: {}
+        name: httpd-logs
       - name: config-data-custom
         secret:
           defaultMode: 416
@@ -281,6 +391,37 @@ spec:
     spec:
       containers:
       - args:
+        - --single-child
+        - --
+        - /usr/bin/tail
+        - -n+1
+        - -F
+        - /var/log/heat/heat-engine.log
+        command:
+        - /usr/bin/dumb-init
+        volumeMounts:
+        - mountPath: /usr/local/bin/container-scripts
+          name: scripts
+          readOnly: true
+        - mountPath: /var/lib/config-data/merged
+          name: config-data-merged
+        - mountPath: /etc/my.cnf
+          name: config-data
+          readOnly: true
+          subPath: my.cnf
+        - mountPath: /var/log/heat
+          name: heat-logs
+        - mountPath: /var/log/httpd
+          name: httpd-logs
+        - mountPath: /var/lib/kolla/config_files/config.json
+          name: config-data-merged
+          readOnly: true
+          subPath: heat-engine-config.json
+        - mountPath: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+          name: combined-ca-bundle
+          readOnly: true
+          subPath: tls-ca-bundle.pem
+      - args:
         - -c
         - /usr/local/bin/kolla_start
         volumeMounts:
@@ -293,6 +434,10 @@ spec:
           name: config-data
           readOnly: true
           subPath: my.cnf
+        - mountPath: /var/log/heat
+          name: heat-logs
+        - mountPath: /var/log/httpd
+          name: httpd-logs
         - mountPath: /var/lib/kolla/config_files/config.json
           name: config-data-merged
           readOnly: true
@@ -317,6 +462,8 @@ spec:
           name: config-data
           readOnly: true
           subPath: my.cnf
+        - mountPath: /var/log/heat
+          name: heat-logs
         - mountPath: /var/lib/config-data/custom
           name: config-data-custom
           readOnly: true
@@ -335,6 +482,10 @@ spec:
           secretName: heat-config-data
       - emptyDir: {}
         name: config-data-merged
+      - emptyDir: {}
+        name: heat-logs
+      - emptyDir: {}
+        name: httpd-logs
       - name: config-data-custom
         secret:
           defaultMode: 416


### PR DESCRIPTION
This change implements cluster logging for Heat engine as described by:
https://kubernetes.io/docs/concepts/cluster-administration/logging/\#cluster-level-logging-architectures