### PR TITLE
Add functional tests and HeatSpec webhook validation

### DIFF
--- a/api/v1beta1/heat_webhook.go
+++ b/api/v1beta1/heat_webhook.go
@@ -186,7 +186,7 @@ func (r *HeatSpec) ValidateUpdate(old HeatSpec, basePath *field.Path, annotation
 		// We currently have no logic in place to perform database migrations. Changing databases
 		// would render all of the existing stacks unmanageable. We should block changes to the
 		// databaseInstance to protect existing workloads.
-		if r.DatabaseInstance != old.DatabaseInstance {
+		if old.DatabaseInstance != "" && r.DatabaseInstance != old.DatabaseInstance {
 			allErrs = append(allErrs, field.Forbidden(
 				field.NewPath("spec.databaseInstance"),
 				"Changing the DatabaseInstance is not supported for existing deployments"))

--- a/tests/functional/heat_webhook_test.go
+++ b/tests/functional/heat_webhook_test.go
@@ -185,4 +185,26 @@ var _ = Describe("Heat Webhook", func() {
 			}).Should(Succeed())
 		})
 	})
+
+	When("The DatabaseInstance is changed for existing deployments from null to something valid", func() {
+		BeforeEach(func() {
+
+			heatSpecNullDBInstance := map[string]interface{}{
+				"databaseInstance": "",
+				"secret":           SecretName,
+				"heatEngine":       GetDefaultHeatEngineSpec(),
+				"heatAPI":          GetDefaultHeatAPISpec(),
+				"heatCfnAPI":       GetDefaultHeatCFNAPISpec(),
+			}
+			DeferCleanup(th.DeleteInstance, CreateHeat(heatName, heatSpecNullDBInstance))
+		})
+
+		It("Should be accepted by the webhook", func() {
+			Eventually(func(g Gomega) {
+				instance := GetHeat(heatName)
+				instance.Spec.DatabaseInstance = "new-database"
+				g.Expect(th.K8sClient.Update(th.Ctx, instance)).Should(Succeed())
+			}).Should(Succeed())
+		})
+	})
 })


### PR DESCRIPTION
We added a webhook validation for the HeatSpecCore struct in: https://github.com/openstack-k8s-operators/heat-operator/pull/407

However, we also need the same validation added to the HeatSpec ValidateUpdate function. This change adds the missing validation, along with a functional test to verify it works.