### PR TITLE
Tidy up condition handling

### DIFF
--- a/api/v1beta1/heat_types.go
+++ b/api/v1beta1/heat_types.go
@@ -196,6 +196,27 @@ func (instance Heat) RbacResourceName() string {
 	return "heat-" + instance.Name
 }
 
+// StatusConditionsList - Returns a list of conditions relevant to our Controller.
+func (instance Heat) StatusConditionsList() condition.Conditions {
+	return condition.CreateList(
+		condition.UnknownCondition(condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage),
+		condition.UnknownCondition(condition.DBReadyCondition, condition.InitReason, condition.DBReadyInitMessage),
+		condition.UnknownCondition(condition.DBSyncReadyCondition, condition.InitReason, condition.DBSyncReadyInitMessage),
+		condition.UnknownCondition(condition.MemcachedReadyCondition, condition.InitReason, condition.MemcachedReadyInitMessage),
+		condition.UnknownCondition(condition.RabbitMqTransportURLReadyCondition, condition.InitReason, condition.RabbitMqTransportURLReadyInitMessage),
+		condition.UnknownCondition(condition.InputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
+		condition.UnknownCondition(condition.ServiceConfigReadyCondition, condition.InitReason, condition.ServiceConfigReadyInitMessage),
+		condition.UnknownCondition(HeatStackDomainReadyCondition, condition.InitReason, HeatStackDomainReadyInitMessage),
+		condition.UnknownCondition(HeatAPIReadyCondition, condition.InitReason, HeatAPIReadyInitMessage),
+		condition.UnknownCondition(HeatCfnAPIReadyCondition, condition.InitReason, HeatCfnAPIReadyInitMessage),
+		condition.UnknownCondition(HeatEngineReadyCondition, condition.InitReason, HeatEngineReadyInitMessage),
+		// service account, role, rolebinding conditions
+		condition.UnknownCondition(condition.ServiceAccountReadyCondition, condition.InitReason, condition.ServiceAccountReadyInitMessage),
+		condition.UnknownCondition(condition.RoleReadyCondition, condition.InitReason, condition.RoleReadyInitMessage),
+		condition.UnknownCondition(condition.RoleBindingReadyCondition, condition.InitReason, condition.RoleBindingReadyInitMessage),
+	)
+}
+
 // SetupDefaults - initializes any CRD field defaults based on environment variables (the defaulting mechanism itself is implemented via webhooks)
 func SetupDefaults() {
 	// Acquire environmental defaults and initialize Heat defaults with them

--- a/api/v1beta1/heatapi_types.go
+++ b/api/v1beta1/heatapi_types.go
@@ -112,6 +112,21 @@ func init() {
 	SchemeBuilder.Register(&HeatAPI{}, &HeatAPIList{})
 }
 
+// StatusConditionsList - Returns a list of conditions relevant to our Controller.
+func (instance HeatAPI) StatusConditionsList() condition.Conditions {
+	return condition.CreateList(
+		condition.UnknownCondition(condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage),
+		condition.UnknownCondition(condition.ExposeServiceReadyCondition, condition.InitReason, condition.ExposeServiceReadyInitMessage),
+		condition.UnknownCondition(condition.InputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
+		condition.UnknownCondition(condition.ServiceConfigReadyCondition, condition.InitReason, condition.ServiceConfigReadyInitMessage),
+		condition.UnknownCondition(condition.DeploymentReadyCondition, condition.InitReason, condition.DeploymentReadyInitMessage),
+		// right now we have no dedicated KeystoneServiceReadyInitMessage and KeystoneEndpointReadyInitMessage
+		condition.UnknownCondition(condition.KeystoneServiceReadyCondition, condition.InitReason, ""),
+		condition.UnknownCondition(condition.KeystoneEndpointReadyCondition, condition.InitReason, ""),
+		condition.UnknownCondition(condition.TLSInputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
+	)
+}
+
 // IsReady - returns true if HeatAPI is reconciled successfully
 func (instance HeatAPI) IsReady() bool {
 	return instance.Status.Conditions.IsTrue(condition.ReadyCondition)

--- a/api/v1beta1/heatcfnapi_types.go
+++ b/api/v1beta1/heatcfnapi_types.go
@@ -113,6 +113,21 @@ func init() {
 	SchemeBuilder.Register(&HeatCfnAPI{}, &HeatCfnAPIList{})
 }
 
+// StatusConditionsList - Returns a list of conditions relevant to our Controller.
+func (instance *HeatCfnAPI) StatusConditionsList() condition.Conditions {
+	return condition.CreateList(
+		condition.UnknownCondition(condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage),
+		condition.UnknownCondition(condition.ExposeServiceReadyCondition, condition.InitReason, condition.ExposeServiceReadyInitMessage),
+		condition.UnknownCondition(condition.InputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
+		condition.UnknownCondition(condition.ServiceConfigReadyCondition, condition.InitReason, condition.ServiceConfigReadyInitMessage),
+		condition.UnknownCondition(condition.DeploymentReadyCondition, condition.InitReason, condition.DeploymentReadyInitMessage),
+		// right now we have no dedicated KeystoneServiceReadyInitMessage and KeystoneEndpointReadyInitMessage
+		condition.UnknownCondition(condition.KeystoneServiceReadyCondition, condition.InitReason, ""),
+		condition.UnknownCondition(condition.KeystoneEndpointReadyCondition, condition.InitReason, ""),
+		condition.UnknownCondition(condition.TLSInputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
+	)
+}
+
 // IsReady - returns true if HeatCfnAPI is reconciled successfully
 func (instance HeatCfnAPI) IsReady() bool {
 	return instance.Status.Conditions.IsTrue(condition.ReadyCondition)

--- a/api/v1beta1/heatengine_types.go
+++ b/api/v1beta1/heatengine_types.go
@@ -108,6 +108,17 @@ func init() {
 	SchemeBuilder.Register(&HeatEngine{}, &HeatEngineList{})
 }
 
+// StatusConditionsList - Returns a list of conditions relevant to our Controller.
+func (instance HeatEngine) StatusConditionsList() condition.Conditions {
+	return condition.CreateList(
+		condition.UnknownCondition(condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage),
+		condition.UnknownCondition(condition.InputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
+		condition.UnknownCondition(condition.ServiceConfigReadyCondition, condition.InitReason, condition.ServiceConfigReadyInitMessage),
+		condition.UnknownCondition(condition.DeploymentReadyCondition, condition.InitReason, condition.DeploymentReadyInitMessage),
+		condition.UnknownCondition(condition.TLSInputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
+	)
+}
+
 // IsReady - returns true if HeatEngine is reconciled successfully
 func (instance HeatEngine) IsReady() bool {
 	return instance.Status.Conditions.IsTrue(condition.ReadyCondition)


### PR DESCRIPTION
This change does some tidy up of how we handle conditions. It deduplicates the code that determines if we're initializing or copy conditions and seperates logic into distinct functions