### PR TITLE
Refacter service secrets function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ PROC_CMD = --procs ${PROCS}
 
 .PHONY: test
 test: manifests generate gowork fmt vet envtest ginkgo ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" $(GINKGO) --trace --cover --coverpkg=../../pkg/...,../../controllers,../../api/v1beta1 --coverprofile cover.out --covermode=atomic ${PROC_CMD} $(GINKGO_ARGS) ./tests/...
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" $(GINKGO) --trace --cover --coverpkg=../../pkg/...,../../controllers,../../api/v1beta1 --coverprofile cover.out --covermode=atomic ${PROC_CMD} $(GINKGO_ARGS) ./tests/... ./controllers/...
 ##@ Build
 
 .PHONY: build

--- a/controllers/heat_controller_test.go
+++ b/controllers/heat_controller_test.go
@@ -1,0 +1,62 @@
+package controllers
+
+import (
+	"reflect"
+	"testing"
+
+	heatv1beta1 "github.com/openstack-k8s-operators/heat-operator/api/v1beta1"
+
+	"github.com/openstack-k8s-operators/lib-common/modules/common/service"
+)
+
+func TestRenderVhost(t *testing.T) {
+	instanceTest1 := &heatv1beta1.Heat{}
+	instanceTest1.Namespace = "test1HeatNamespace"
+
+	tests := []struct {
+		name        string
+		instance    *heatv1beta1.Heat
+		endpt       service.Endpoint
+		serviceName string
+		tlsEnabled  bool
+		expected    map[string]interface{}
+	}{
+		{
+			name:        "Basic case with TLS disabled",
+			instance:    instanceTest1,
+			endpt:       "internal",
+			serviceName: "my-service",
+			tlsEnabled:  false,
+			expected: map[string]interface{}{
+				"internal": map[string]interface{}{
+					"ServerName": "my-service-internal.test1HeatNamespace.svc",
+					"TLS":        false,
+				},
+			},
+		},
+		{
+			name:        "Basic case with TLS enabled",
+			instance:    instanceTest1,
+			endpt:       "public",
+			serviceName: "my-service",
+			tlsEnabled:  true,
+			expected: map[string]interface{}{
+				"public": map[string]interface{}{
+					"ServerName":            "my-service-public.test1HeatNamespace.svc",
+					"TLS":                   true,
+					"SSLCertificateFile":    "/etc/pki/tls/certs/public.crt",
+					"SSLCertificateKeyFile": "/etc/pki/tls/private/public.key",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := renderVhost(tt.instance, tt.endpt, tt.serviceName, tt.tlsEnabled)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("Expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}

--- a/tests/functional/heat_controller_test.go
+++ b/tests/functional/heat_controller_test.go
@@ -343,6 +343,10 @@ var _ = Describe("Heat controller", func() {
 				ContainSubstring("tls_enabled=false"))
 			Expect(string(cm.Data["my.cnf"])).To(
 				ContainSubstring("[client]\nssl=0"))
+			Expect(string(cm.Data["heat-api-httpd.conf"])).To(
+				ContainSubstring(fmt.Sprintf("heat-api-public.%s.svc", heatName.Namespace)))
+			Expect(string(cm.Data["heat-cfnapi-httpd.conf"])).To(
+				ContainSubstring(fmt.Sprintf("heat-cfnapi-public.%s.svc", heatName.Namespace)))
 		})
 	})
 


### PR DESCRIPTION
This change refactors the generateServiceSecrets function to deduplicate code and move logic related to vhosts and templateParameters into dedicated functions.