### PR TITLE
Set minimum Go version via env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,9 @@ IMG ?= $(DEFAULT_IMG)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.28
 
+# Set minimum Go version
+GOTOOLCHAIN_VERSION ?= go1.21.0
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -317,7 +320,7 @@ operator-lint: gowork ## Runs operator-lint
 
 .PHONY: gowork
 gowork: ## Generate go.work file
-	test -f go.work || go work init
+	test -f go.work || GOTOOLCHAIN=$(GOTOOLCHAIN_VERSION) go work init
 	go work use .
 	go work use ./api
 	go work sync


### PR DESCRIPTION
GOTOOLCHAIN to set 1.21.0 as the min required version and sets it in go.work file.