### PR TITLE
Validate AuthEncryptionKey length

### DIFF
--- a/controllers/heat_controller.go
+++ b/controllers/heat_controller.go
@@ -952,7 +952,10 @@ func (r *HeatReconciler) generateServiceSecrets(
 		return err
 	}
 	password := strings.TrimSuffix(string(ospSecret.Data[instance.Spec.PasswordSelectors.Service]), "\n")
-	authEncryptionKey := strings.TrimSuffix(string(ospSecret.Data[instance.Spec.PasswordSelectors.AuthEncryptionKey]), "\n")
+	authEncryptionKey, err := validateAuthEncryptionKey(instance, ospSecret)
+	if err != nil {
+		return err
+	}
 
 	transportURLSecret, _, err := oko_secret.GetSecret(ctx, h, instance.Status.TransportURLSecret, instance.Namespace)
 	if err != nil {
@@ -1346,4 +1349,19 @@ func renderVhost(instance *heatv1beta1.Heat, endpt service.Endpoint, serviceName
 	httpdVhostConfig[endpt.String()] = endptConfig
 
 	return httpdVhostConfig
+}
+
+// validateAuthEncryptionKey - the heat_auth_encrption_key needs to be 32 characters long. This function validates
+// the length of the user provided key and returns an error if it isn't long enough.
+func validateAuthEncryptionKey(instance *heatv1beta1.Heat, ospSecret *corev1.Secret) (string, error) {
+	const HeatAuthEncKeyLen int = 32
+
+	heatAuthEncKey := strings.TrimSuffix(string(ospSecret.Data[instance.Spec.PasswordSelectors.AuthEncryptionKey]), "\n")
+
+	if len(heatAuthEncKey) < HeatAuthEncKeyLen {
+		return "", fmt.Errorf("AuthEncryptionKey must be at least %d characters", HeatAuthEncKeyLen)
+	}
+
+	return heatAuthEncKey, nil
+
 }

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -34,6 +34,9 @@ func GetDefaultHeatSpec() map[string]interface{} {
 		"heatEngine":       GetDefaultHeatEngineSpec(),
 		"heatAPI":          GetDefaultHeatAPISpec(),
 		"heatCfnAPI":       GetDefaultHeatCFNAPISpec(),
+		"passwordSelectors": map[string]interface{}{
+			"AuthEncryptionKey": "HeatAuthEncryptionKey",
+		},
 	}
 }
 
@@ -75,8 +78,8 @@ func CreateHeatSecret(namespace string, name string) *corev1.Secret {
 	return th.CreateSecret(
 		types.NamespacedName{Namespace: namespace, Name: name},
 		map[string][]byte{
-			"HeatPassword":      []byte("12345678"),
-			"AuthEncryptionKey": []byte("1234567812345678123456781212345678345678"),
+			"HeatPassword":          []byte("12345678"),
+			"HeatAuthEncryptionKey": []byte("1234567812345678123456781212345678345678"),
 		},
 	)
 }


### PR DESCRIPTION
If a user provides a AuthEncryptionKey less than 32 characters, the Heat service will fail to start and pods will CrashLoopBackOff. This change validates the length of the provided value to ensure we can return an error early rather than waiting until the service is trying to initialize.

Jira: https://issues.redhat.com/browse/OSPRH-10506