### PR TITLE
Make sure to log error in findObjectsForSrc()

### DIFF
--- a/controllers/heat_controller.go
+++ b/controllers/heat_controller.go
@@ -289,7 +289,8 @@ func (r *HeatReconciler) findObjectsForSrc(ctx context.Context, src client.Objec
 		}
 		err := r.List(ctx, crList, listOps)
 		if err != nil {
-			return []reconcile.Request{}
+			l.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
+			return requests
 		}
 
 		for _, item := range crList.Items {

--- a/controllers/heatapi_controller.go
+++ b/controllers/heatapi_controller.go
@@ -288,7 +288,8 @@ func (r *HeatAPIReconciler) findObjectsForSrc(ctx context.Context, src client.Ob
 		}
 		err := r.List(ctx, crList, listOps)
 		if err != nil {
-			return []reconcile.Request{}
+			l.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
+			return requests
 		}
 
 		for _, item := range crList.Items {

--- a/controllers/heatcfnapi_controller.go
+++ b/controllers/heatcfnapi_controller.go
@@ -290,7 +290,8 @@ func (r *HeatCfnAPIReconciler) findObjectsForSrc(ctx context.Context, src client
 		}
 		err := r.List(ctx, crList, listOps)
 		if err != nil {
-			return []reconcile.Request{}
+			l.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
+			return requests
 		}
 
 		for _, item := range crList.Items {

--- a/controllers/heatengine_controller.go
+++ b/controllers/heatengine_controller.go
@@ -237,7 +237,8 @@ func (r *HeatEngineReconciler) findObjectsForSrc(ctx context.Context, src client
 		}
 		err := r.List(ctx, crList, listOps)
 		if err != nil {
-			return []reconcile.Request{}
+			l.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
+			return requests
 		}
 
 		for _, item := range crList.Items {


### PR DESCRIPTION
It is hidden right now if there is an error in configured named fields and index. Lets log the error and return the current state of requests.

With this the findObjectsForSrc() will exit with an hidden error like:

```
"error": "Index with name field:.spec.ksmTls.caBundleSecretName does not exist"
```