### PR TITLE
Don't create stack_domain_admin user with project

### DIFF
--- a/controllers/heat_controller.go
+++ b/controllers/heat_controller.go
@@ -1081,10 +1081,9 @@ func (r *HeatReconciler) ensureStackDomain(
 	userID, err := os.CreateUser(
 		r.Log,
 		openstack.User{
-			Name:      heat.StackDomainAdminUsername,
-			Password:  password,
-			ProjectID: "service",
-			DomainID:  domainID,
+			Name:     heat.StackDomainAdminUsername,
+			Password: password,
+			DomainID: domainID,
 		})
 	if err != nil {
 		return ctrl.Result{}, err


### PR DESCRIPTION
This may result in a project scoped token issued that can't create projects in the domain i.e only a domain scoped token can create projects in the domain.