### PR TITLE
Skip Heat tempest tests with known issues upstream

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -30,9 +30,36 @@
         heat_tempest_plugin.tests.scenario.test_server_cfn_init.CfnInitIntegrationTest.test_server_cfn_init
         heat_tempest_plugin.tests.scenario.test_aodh_alarm.AodhAlarmTest.test_alarm
         heat_tempest_plugin.tests.scenario.test_base_resources.BasicResourcesTest.test_base_resources_integration
+        heat_tempest_plugin.tests.scenario.test_server_software_config.SoftwareConfigIntegrationTest.test_server_software_config
+        heat_tempest_plugin.tests.scenario.test_octavia_lbaas.LoadBalancerTest
+        heat_tempest_plugin.tests.scenario.test_aodh_alarm.AodhAlarmTest.test_alarm
         heat_tempest_plugin.tests.scenario.test_server_signal.ServerSignalIntegrationTest.test_server_signal_userdata_format_raw
         heat_tempest_plugin.tests.scenario.test_server_signal.ServerSignalIntegrationTest.test_server_signal_userdata_format_software_config
-        heat_tempest_plugin.tests.scenario.test_server_software_config.SoftwareConfigIntegrationTest.test_server_software_config
+        heat_integrationtests.functional.test_aws_stack
+        heat_integrationtests.functional.test_cancel_update.CancelUpdateTest.test_cancel_update_server_with_port
+        heat_integrationtests.functional.test_reload_on_sighup
+        heat_integrationtests.functional.test_resource_group.ResourceGroupAdoptTest.test_adopt
+        heat_integrationtests.functional.test_software_config.ZaqarSignalTransportTest.test_signal_queues
+        heat_integrationtests.functional.test_waitcondition.ZaqarWaitConditionTest
+        heat_integrationtests.functional.test_event_sinks.ZaqarEventSinkTest.test_events
+        heat_integrationtests.functional.test_stack_tags.StackTagTest.test_hidden_stack
+        heat_integrationtests.functional.test_template_resource.TemplateResourceAdoptTest
+        heat_integrationtests.functional.test_purge.PurgeTest.test_purge
+        heat_integrationtests.functional.test_notifications.NotificationTest
+        heat_integrationtests.functional.test_os_wait_condition.OSWaitCondition
+        heat_integrationtests.scenario.test_base_resources.BasicResourcesTest.test_base_resources_integration
+        heat_integrationtests.scenario.test_server_software_config
+        heat_integrationtests.scenario.test_volumes
+        heat_integrationtests.scenario.test_server_cfn_init
+        heat_tempest_plugin.tests.functional.test_aws_stack
+        heat_tempest_plugin.tests.functional.test_software_config.ZaqarSignalTransportTest.test_signal_queues
+        heat_tempest_plugin.tests.functional.test_waitcondition.ZaqarWaitConditionTest
+        heat_tempest_plugin.tests.functional.test_event_sinks.ZaqarEventSinkTest.test_events
+        heat_tempest_plugin.tests.functional.test_os_wait_condition.OSWaitCondition
+        heat_tempest_plugin.tests.scenario.test_base_resources.BasicResourcesTest.test_base_resources_integration
+        heat_tempest_plugin.tests.scenario.test_server_software_config
+        heat_tempest_plugin.tests.scenario.test_volumes
+        heat_tempest_plugin.tests.scenario.test_server_cfn_init
       external_plugin: "opendev.org/openstack/heat-tempest-plugin"
       change_item: "{{ zuul['items'] | selectattr('project.canonical_name', 'equalto', external_plugin) }}"
       cifmw_test_operator_tempest_external_plugin: "{{ [] if change_item | length < 1 else [ { 'repository': 'https://' + external_plugin + '.git', 'changeRepository': 'https://review' + external_plugin, 'changeRefspec': [ 'refs/changes', change_item[0].change[-2:], change_item[0].change, change_item[0].patchset ] | join('/') } ] }}"


### PR DESCRIPTION
This change adds specific tempest tests that are known to not work upstream. Some issues for example include the lack of valid DNS server and the dependency on DNS to work with TLS endpoints that are enabled by default.