### PR TITLE
Add HeatStackDomainAdminPassword to heat passwords

### DIFF
--- a/api/bases/heat.openstack.org_heatapis.yaml
+++ b/api/bases/heat.openstack.org_heatapis.yaml
@@ -275,6 +275,11 @@ spec:
                     description: Service - Selector to get the heat service password
                       from the Secret
                     type: string
+                  stackDomainAdminPassword:
+                    default: HeatStackDomainAdminPassword
+                    description: StackDomainAdminPassword - Selector to get the heat
+                      stack domain admin password from the Secret
+                    type: string
                 type: object
               replicas:
                 default: 1

--- a/api/bases/heat.openstack.org_heatcfnapis.yaml
+++ b/api/bases/heat.openstack.org_heatcfnapis.yaml
@@ -275,6 +275,11 @@ spec:
                     description: Service - Selector to get the heat service password
                       from the Secret
                     type: string
+                  stackDomainAdminPassword:
+                    default: HeatStackDomainAdminPassword
+                    description: StackDomainAdminPassword - Selector to get the heat
+                      stack domain admin password from the Secret
+                    type: string
                 type: object
               replicas:
                 default: 1

--- a/api/bases/heat.openstack.org_heatengines.yaml
+++ b/api/bases/heat.openstack.org_heatengines.yaml
@@ -101,6 +101,11 @@ spec:
                     description: Service - Selector to get the heat service password
                       from the Secret
                     type: string
+                  stackDomainAdminPassword:
+                    default: HeatStackDomainAdminPassword
+                    description: StackDomainAdminPassword - Selector to get the heat
+                      stack domain admin password from the Secret
+                    type: string
                 type: object
               replicas:
                 default: 1

--- a/api/bases/heat.openstack.org_heats.yaml
+++ b/api/bases/heat.openstack.org_heats.yaml
@@ -819,6 +819,11 @@ spec:
                     description: Service - Selector to get the heat service password
                       from the Secret
                     type: string
+                  stackDomainAdminPassword:
+                    default: HeatStackDomainAdminPassword
+                    description: StackDomainAdminPassword - Selector to get the heat
+                      stack domain admin password from the Secret
+                    type: string
                 type: object
               preserveJobs:
                 default: false

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -98,4 +98,8 @@ type PasswordSelector struct {
 	// +kubebuilder:default="HeatAuthEncryptionKey"
 	// AuthEncryptionKey - Selector to get the heat auth encryption key from the Secret
 	AuthEncryptionKey string `json:"authEncryptionKey"`
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default="HeatStackDomainAdminPassword"
+	// StackDomainAdminPassword - Selector to get the heat stack domain admin password from the Secret
+	StackDomainAdminPassword string `json:"stackDomainAdminPassword"`
 }

--- a/config/crd/bases/heat.openstack.org_heatapis.yaml
+++ b/config/crd/bases/heat.openstack.org_heatapis.yaml
@@ -275,6 +275,11 @@ spec:
                     description: Service - Selector to get the heat service password
                       from the Secret
                     type: string
+                  stackDomainAdminPassword:
+                    default: HeatStackDomainAdminPassword
+                    description: StackDomainAdminPassword - Selector to get the heat
+                      stack domain admin password from the Secret
+                    type: string
                 type: object
               replicas:
                 default: 1

--- a/config/crd/bases/heat.openstack.org_heatcfnapis.yaml
+++ b/config/crd/bases/heat.openstack.org_heatcfnapis.yaml
@@ -275,6 +275,11 @@ spec:
                     description: Service - Selector to get the heat service password
                       from the Secret
                     type: string
+                  stackDomainAdminPassword:
+                    default: HeatStackDomainAdminPassword
+                    description: StackDomainAdminPassword - Selector to get the heat
+                      stack domain admin password from the Secret
+                    type: string
                 type: object
               replicas:
                 default: 1

--- a/config/crd/bases/heat.openstack.org_heatengines.yaml
+++ b/config/crd/bases/heat.openstack.org_heatengines.yaml
@@ -101,6 +101,11 @@ spec:
                     description: Service - Selector to get the heat service password
                       from the Secret
                     type: string
+                  stackDomainAdminPassword:
+                    default: HeatStackDomainAdminPassword
+                    description: StackDomainAdminPassword - Selector to get the heat
+                      stack domain admin password from the Secret
+                    type: string
                 type: object
               replicas:
                 default: 1

--- a/config/crd/bases/heat.openstack.org_heats.yaml
+++ b/config/crd/bases/heat.openstack.org_heats.yaml
@@ -819,6 +819,11 @@ spec:
                     description: Service - Selector to get the heat service password
                       from the Secret
                     type: string
+                  stackDomainAdminPassword:
+                    default: HeatStackDomainAdminPassword
+                    description: StackDomainAdminPassword - Selector to get the heat
+                      stack domain admin password from the Secret
+                    type: string
                 type: object
               preserveJobs:
                 default: false

--- a/templates/heat/config/00-default.conf
+++ b/templates/heat/config/00-default.conf
@@ -2,7 +2,7 @@
 region_name_for_services=regionOne
 stack_user_domain_name={{ .StackDomainName }}
 stack_domain_admin={{ .StackDomainAdminUsername }}
-stack_domain_admin_password={{ .ServicePassword }}
+stack_domain_admin_password={{ .StackDomainAdminPassword }}
 num_engine_workers=4
 auth_encryption_key={{ .AuthEncryptionKey }}
 use_stderr=true

--- a/tests/kuttl/common/assert-sample-deployment.yaml
+++ b/tests/kuttl/common/assert-sample-deployment.yaml
@@ -32,6 +32,7 @@ spec:
   memcachedInstance: memcached
   passwordSelectors:
     authEncryptionKey: HeatAuthEncryptionKey
+    stackDomainAdminPassword: HeatStackDomainAdminPassword
     service: HeatPassword
   preserveJobs: false
   rabbitMqClusterName: rabbitmq
@@ -61,6 +62,7 @@ spec:
   databaseAccount: heat
   passwordSelectors:
     authEncryptionKey: HeatAuthEncryptionKey
+    stackDomainAdminPassword: HeatStackDomainAdminPassword
     service: HeatPassword
   replicas: 1
   resources: {}
@@ -88,6 +90,7 @@ spec:
   databaseAccount: heat
   passwordSelectors:
     authEncryptionKey: HeatAuthEncryptionKey
+    stackDomainAdminPassword: HeatStackDomainAdminPassword
     service: HeatPassword
   replicas: 1
   resources: {}
@@ -115,6 +118,7 @@ spec:
   databaseAccount: heat
   passwordSelectors:
     authEncryptionKey: HeatAuthEncryptionKey
+    stackDomainAdminPassword: HeatStackDomainAdminPassword
     service: HeatPassword
   replicas: 1
   resources: {}


### PR DESCRIPTION
This is different in OSP 17.1 environments and we can't assume it to be the same as service password.

jira: https://issues.redhat.com/browse/OSPRH-10914