### PR TITLE
Index the customServiceConfigSecrets for use in the Secret lookup

### DIFF
--- a/controllers/heat_controller.go
+++ b/controllers/heat_controller.go
@@ -225,6 +225,18 @@ func (r *HeatReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
+	// index customServiceConfigSecrets
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &heatv1beta1.Heat{}, customServiceConfigField, func(rawObj client.Object) []string {
+		// Extract the secret name from the spec, if one is provided
+		cr := rawObj.(*heatv1beta1.Heat)
+		if cr.Spec.CustomServiceConfigSecrets == nil {
+			return nil
+		}
+		return cr.Spec.CustomServiceConfigSecrets
+	}); err != nil {
+		return err
+	}
+
 	memcachedFn := func(_ context.Context, o client.Object) []reconcile.Request {
 		result := []reconcile.Request{}
 

--- a/controllers/heatapi_controller.go
+++ b/controllers/heatapi_controller.go
@@ -225,6 +225,18 @@ func (r *HeatAPIReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
+	// index customServiceConfigSecrets
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &heatv1beta1.HeatAPI{}, customServiceConfigField, func(rawObj client.Object) []string {
+		// Extract the secret name from the spec, if one is provided
+		cr := rawObj.(*heatv1beta1.HeatAPI)
+		if cr.Spec.CustomServiceConfigSecrets == nil {
+			return nil
+		}
+		return cr.Spec.CustomServiceConfigSecrets
+	}); err != nil {
+		return err
+	}
+
 	configMapFn := func(_ context.Context, o client.Object) []reconcile.Request {
 		result := []reconcile.Request{}
 

--- a/controllers/heatcfnapi_controller.go
+++ b/controllers/heatcfnapi_controller.go
@@ -227,6 +227,18 @@ func (r *HeatCfnAPIReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
+	// index customServiceConfigSecrets
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &heatv1beta1.HeatCfnAPI{}, customServiceConfigField, func(rawObj client.Object) []string {
+		// Extract the secret name from the spec, if one is provided
+		cr := rawObj.(*heatv1beta1.HeatCfnAPI)
+		if cr.Spec.CustomServiceConfigSecrets == nil {
+			return nil
+		}
+		return cr.Spec.CustomServiceConfigSecrets
+	}); err != nil {
+		return err
+	}
+
 	configMapFn := func(_ context.Context, o client.Object) []reconcile.Request {
 		result := []reconcile.Request{}
 

--- a/controllers/heatengine_controller.go
+++ b/controllers/heatengine_controller.go
@@ -179,6 +179,18 @@ func (r *HeatEngineReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
+	// index customServiceConfigSecrets
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &heatv1beta1.HeatEngine{}, customServiceConfigField, func(rawObj client.Object) []string {
+		// Extract the secret name from the spec, if one is provided
+		cr := rawObj.(*heatv1beta1.HeatEngine)
+		if cr.Spec.CustomServiceConfigSecrets == nil {
+			return nil
+		}
+		return cr.Spec.CustomServiceConfigSecrets
+	}); err != nil {
+		return err
+	}
+
 	configMapFn := func(_ context.Context, o client.Object) []reconcile.Request {
 		result := []reconcile.Request{}
 


### PR DESCRIPTION
This change ensures the customServiceConfigSecrets value is indexed for when we need to use it in the FindObjectsForSrc function