### PR TITLE
Add configurable API Timeouts

### DIFF
--- a/api/bases/heat.openstack.org_heats.yaml
+++ b/api/bases/heat.openstack.org_heats.yaml
@@ -44,6 +44,11 @@ spec:
           spec:
             description: HeatSpec defines the desired state of Heat
             properties:
+              apiTimeout:
+                default: 600
+                description: APITimeout for Route and Apache
+                minimum: 60
+                type: integer
               customServiceConfig:
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered

--- a/api/v1beta1/heat_types.go
+++ b/api/v1beta1/heat_types.go
@@ -121,6 +121,12 @@ type HeatSpecBase struct {
 	// NodeSelector to target subset of worker nodes for running the Heat services
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=600
+	// +kubebuilder:validation:Minimum=60
+	// APITimeout for Route and Apache
+	APITimeout int `json:"apiTimeout"`
+
 	// Common input parameters for all Heat services
 	HeatTemplate `json:",inline"`
 }

--- a/config/crd/bases/heat.openstack.org_heats.yaml
+++ b/config/crd/bases/heat.openstack.org_heats.yaml
@@ -44,6 +44,11 @@ spec:
           spec:
             description: HeatSpec defines the desired state of Heat
             properties:
+              apiTimeout:
+                default: 600
+                description: APITimeout for Route and Apache
+                minimum: 60
+                type: integer
               customServiceConfig:
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered

--- a/controllers/heat_controller.go
+++ b/controllers/heat_controller.go
@@ -1353,6 +1353,7 @@ func initTemplateParameters(
 		"MemcachedServersWithInet": mc.GetMemcachedServerListWithInetString(),
 		"MemcachedTLS":             mc.GetMemcachedTLSSupport(),
 		"DatabaseConnection":       mysqlConnectionString,
+		"Timeout":                  instance.Spec.APITimeout,
 	}
 }
 

--- a/templates/heat/config/heat-api-httpd.conf
+++ b/templates/heat/config/heat-api-httpd.conf
@@ -53,6 +53,6 @@ ErrorLog /dev/stdout
   WSGIScriptAlias / "/usr/bin/heat-wsgi-api"
   WSGIPassAuthorization On
 
-  Timeout 600
+  Timeout {{ $.Timeout }}
 </VirtualHost>
 {{ end }}

--- a/templates/heat/config/heat-cfnapi-httpd.conf
+++ b/templates/heat/config/heat-cfnapi-httpd.conf
@@ -53,6 +53,6 @@ ErrorLog /dev/stdout
   WSGIScriptAlias / "/usr/bin/heat-wsgi-api-cfn"
   WSGIPassAuthorization On
 
-  Timeout 600
+  Timeout {{ $.Timeout }}
 </VirtualHost>
 {{ end }}


### PR DESCRIPTION
This patch adds an apiTimeout field to the HeatSpecBase to allow human operators to simultaneously configure the timeouts for HAProxy, Apache, and the rpc_response_timeout.

The apiTimeout defaults to 60 seconds, to mimic the behavior present in OSP17.

Having different timeouts for HAProxy, Apache, and rpc_response_timeout is possible setting the HAProxy timeout in the apiOverride, the Apache timeout with apiTimeout, and setting rpc_response_timeout in the top level Heat customServiceConfig.

To be able to change the HAProxy value based on the apiTimeout with any update (and not just the first time) the code adds a custom annotation "api.heat.openstack.org/timeout" with the value that was initially set, this way flags it as being set by the heat-operator.

closes [OSPRH-10965](https://issues.redhat.com//browse/OSPRH-10965)