### PR TITLE
Ensure nodeSelector logic is consistent for all operators

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -61,7 +61,7 @@ type HeatServiceTemplate struct {
 
 	// +kubebuilder:validation:Optional
 	// NodeSelector to target subset of worker nodes for running the service
-	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+	NodeSelector *map[string]string `json:"nodeSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// CustomServiceConfig - customize the service config using this parameter to change service defaults,

--- a/api/v1beta1/heat_types.go
+++ b/api/v1beta1/heat_types.go
@@ -119,7 +119,7 @@ type HeatSpecBase struct {
 
 	// +kubebuilder:validation:Optional
 	// NodeSelector to target subset of worker nodes for running the Heat services
-	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+	NodeSelector *map[string]string `json:"nodeSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=600

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -556,9 +556,13 @@ func (in *HeatServiceTemplate) DeepCopyInto(out *HeatServiceTemplate) {
 	}
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
+		*out = new(map[string]string)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make(map[string]string, len(*in))
+			for key, val := range *in {
+				(*out)[key] = val
+			}
 		}
 	}
 	if in.CustomServiceConfigSecrets != nil {
@@ -615,9 +619,13 @@ func (in *HeatSpecBase) DeepCopyInto(out *HeatSpecBase) {
 	}
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
+		*out = new(map[string]string)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make(map[string]string, len(*in))
+			for key, val := range *in {
+				(*out)[key] = val
+			}
 		}
 	}
 	out.HeatTemplate = in.HeatTemplate

--- a/controllers/heat_controller.go
+++ b/controllers/heat_controller.go
@@ -835,11 +835,12 @@ func (r *HeatReconciler) apiDeploymentCreateOrUpdate(
 		},
 	}
 
+	if heatAPISpec.NodeSelector == nil {
+		heatAPISpec.NodeSelector = instance.Spec.NodeSelector
+	}
+
 	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, deployment, func() error {
 		deployment.Spec = heatAPISpec
-		if len(deployment.Spec.NodeSelector) == 0 {
-			deployment.Spec.NodeSelector = instance.Spec.NodeSelector
-		}
 		return controllerutil.SetControllerReference(instance, deployment, r.Scheme)
 	})
 
@@ -858,6 +859,10 @@ func (r *HeatReconciler) cfnapiDeploymentCreateOrUpdate(
 		ServiceAccount:     instance.RbacResourceName(),
 	}
 
+	if heatCfnAPISpec.NodeSelector == nil {
+		heatCfnAPISpec.NodeSelector = instance.Spec.NodeSelector
+	}
+
 	deployment := &heatv1beta1.HeatCfnAPI{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-cfnapi", instance.Name),
@@ -867,9 +872,6 @@ func (r *HeatReconciler) cfnapiDeploymentCreateOrUpdate(
 
 	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, deployment, func() error {
 		deployment.Spec = heatCfnAPISpec
-		if len(deployment.Spec.NodeSelector) == 0 {
-			deployment.Spec.NodeSelector = instance.Spec.NodeSelector
-		}
 		return controllerutil.SetControllerReference(instance, deployment, r.Scheme)
 	})
 
@@ -889,6 +891,10 @@ func (r *HeatReconciler) engineDeploymentCreateOrUpdate(
 		TLS:                instance.Spec.HeatAPI.TLS.Ca,
 	}
 
+	if heatEngineSpec.NodeSelector == nil {
+		heatEngineSpec.NodeSelector = instance.Spec.NodeSelector
+	}
+
 	deployment := &heatv1beta1.HeatEngine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-engine", instance.Name),
@@ -898,9 +904,6 @@ func (r *HeatReconciler) engineDeploymentCreateOrUpdate(
 
 	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, deployment, func() error {
 		deployment.Spec = heatEngineSpec
-		if len(deployment.Spec.NodeSelector) == 0 {
-			deployment.Spec.NodeSelector = instance.Spec.NodeSelector
-		}
 		return controllerutil.SetControllerReference(instance, deployment, r.Scheme)
 	})
 

--- a/pkg/heat/dbsync.go
+++ b/pkg/heat/dbsync.go
@@ -82,5 +82,9 @@ func DBSyncJob(
 		},
 	}
 
+	if instance.Spec.NodeSelector != nil {
+		job.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
+	}
+
 	return job
 }

--- a/pkg/heatapi/deployment.go
+++ b/pkg/heatapi/deployment.go
@@ -169,8 +169,8 @@ func Deployment(
 		},
 		corev1.LabelHostname,
 	)
-	if instance.Spec.NodeSelector != nil && len(instance.Spec.NodeSelector) > 0 {
-		deployment.Spec.Template.Spec.NodeSelector = instance.Spec.NodeSelector
+	if instance.Spec.NodeSelector != nil {
+		deployment.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
 	}
 
 	return deployment, nil

--- a/pkg/heatcfnapi/deployment.go
+++ b/pkg/heatcfnapi/deployment.go
@@ -169,8 +169,8 @@ func Deployment(
 		},
 		corev1.LabelHostname,
 	)
-	if instance.Spec.NodeSelector != nil && len(instance.Spec.NodeSelector) > 0 {
-		deployment.Spec.Template.Spec.NodeSelector = instance.Spec.NodeSelector
+	if instance.Spec.NodeSelector != nil {
+		deployment.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
 	}
 
 	return deployment, nil

--- a/pkg/heatengine/deployment.go
+++ b/pkg/heatengine/deployment.go
@@ -139,8 +139,8 @@ func Deployment(instance *heatv1beta1.HeatEngine, configHash string, labels map[
 		},
 		corev1.LabelHostname,
 	)
-	if instance.Spec.NodeSelector != nil && len(instance.Spec.NodeSelector) > 0 {
-		deployment.Spec.Template.Spec.NodeSelector = instance.Spec.NodeSelector
+	if instance.Spec.NodeSelector != nil {
+		deployment.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
 	}
 
 	return deployment


### PR DESCRIPTION
nodeSelectors are not currently applied consistently across all operators.

Some do not support nodeSelectors at all - will be implemented in this series of pull requests.
Some do not apply them to every pod (jobs/cronjobs esp) - will be resolved in this series of pull requests.
Some do not apply a node selector update correctly, only when not initially set.
Some support nodeSelectors but do not inherit the default nodeSelector from the OpenstackControlPlane CR.

Jira: [OSPRH-10734](https://issues.redhat.com//browse/OSPRH-10734)