### PR TITLE
Tls tidy

### DIFF
--- a/controllers/heatengine_controller.go
+++ b/controllers/heatengine_controller.go
@@ -514,8 +514,13 @@ func (r *HeatEngineReconciler) reconcileNormal(
 		return ctrl.Result{}, fmt.Errorf("waiting for Topology requirements: %w", err)
 	}
 
+	deplSpec, err := heatengine.Deployment(instance, inputHash, serviceLabels, topology)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	depl := deployment.NewDeployment(
-		heatengine.Deployment(instance, inputHash, serviceLabels, topology),
+		deplSpec,
 		time.Second*5,
 	)
 

--- a/pkg/heatengine/deployment.go
+++ b/pkg/heatengine/deployment.go
@@ -37,12 +37,9 @@ const (
 )
 
 // Deployment func
-func Deployment(
-	instance *heatv1beta1.HeatEngine,
-	configHash string,
-	labels map[string]string,
-	topology *topologyv1.Topology,
-) *appsv1.Deployment {
+func Deployment(instance *heatv1beta1.HeatEngine, configHash string, labels map[string]string, topology *topologyv1.Topology) (*appsv1.Deployment, error) {
+
+	var err error
 
 	livenessProbe := formatProbes()
 	readinessProbe := formatProbes()
@@ -134,7 +131,7 @@ func Deployment(
 		)
 	}
 
-	return deployment
+	return deployment, err
 }
 
 func formatProbes() *corev1.Probe {


### PR DESCRIPTION
Move mounts and volumes to dedicated function. This declutters the Deployment logic and makes each component easier to test. Particularly for Heat where we have some challenges with EnvTest and mocking the OpenStack API.

- Move Volume and VolumeMount creation to dedicated function
- Move TLS handling to dedicated functions for HeatAPI and HeatCfnAPI
- Return errors from HeatEngine deployment creation process if any formatting fails.
- Handle errors in the reconcile flow for HeatEngine controller.