### PR TITLE
Make sure we reconcile heat-engine secrets

### DIFF
--- a/controllers/heatapi_controller.go
+++ b/controllers/heatapi_controller.go
@@ -257,7 +257,7 @@ func (r *HeatAPIReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
-	configMapFn := func(_ context.Context, o client.Object) []reconcile.Request {
+	secretFn := func(_ context.Context, o client.Object) []reconcile.Request {
 		result := []reconcile.Request{}
 
 		apis := &heatv1beta1.HeatAPIList{}
@@ -278,7 +278,7 @@ func (r *HeatAPIReconciler) SetupWithManager(mgr ctrl.Manager) error {
 						Namespace: o.GetNamespace(),
 						Name:      cr.Name,
 					}
-					r.Log.Info(fmt.Sprintf("ConfigMap object %s and CR %s marked with label: %s", o.GetName(), cr.Name, l))
+					r.Log.Info(fmt.Sprintf("secret object %s and CR %s marked with label: %s", o.GetName(), cr.Name, l))
 					result = append(result, reconcile.Request{NamespacedName: name})
 				}
 			}
@@ -296,8 +296,8 @@ func (r *HeatAPIReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		// watch the config CMs we don't own
-		Watches(&corev1.ConfigMap{},
-			handler.EnqueueRequestsFromMapFunc(configMapFn)).
+		Watches(&corev1.Secret{},
+			handler.EnqueueRequestsFromMapFunc(secretFn)).
 		Watches(
 			&corev1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(r.findObjectsForSrc),

--- a/controllers/heatcfnapi_controller.go
+++ b/controllers/heatcfnapi_controller.go
@@ -259,7 +259,7 @@ func (r *HeatCfnAPIReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
-	configMapFn := func(_ context.Context, o client.Object) []reconcile.Request {
+	secretFn := func(_ context.Context, o client.Object) []reconcile.Request {
 		result := []reconcile.Request{}
 
 		apis := &heatv1beta1.HeatCfnAPIList{}
@@ -280,7 +280,7 @@ func (r *HeatCfnAPIReconciler) SetupWithManager(mgr ctrl.Manager) error {
 						Namespace: o.GetNamespace(),
 						Name:      cr.Name,
 					}
-					r.Log.Info(fmt.Sprintf("ConfigMap object %s and CR %s marked with label: %s", o.GetName(), cr.Name, l))
+					r.Log.Info(fmt.Sprintf("secret object %s and CR %s marked with label: %s", o.GetName(), cr.Name, l))
 					result = append(result, reconcile.Request{NamespacedName: name})
 				}
 			}
@@ -297,9 +297,8 @@ func (r *HeatCfnAPIReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&keystonev1.KeystoneEndpoint{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
-		// watch the config CMs we don't own
-		Watches(&corev1.ConfigMap{},
-			handler.EnqueueRequestsFromMapFunc(configMapFn)).
+		Watches(&corev1.Secret{},
+			handler.EnqueueRequestsFromMapFunc(secretFn)).
 		Watches(
 			&corev1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(r.findObjectsForSrc),

--- a/controllers/heatengine_controller.go
+++ b/controllers/heatengine_controller.go
@@ -210,7 +210,7 @@ func (r *HeatEngineReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
-	configMapFn := func(_ context.Context, o client.Object) []reconcile.Request {
+	secretFn := func(_ context.Context, o client.Object) []reconcile.Request {
 		result := []reconcile.Request{}
 
 		engines := &heatv1beta1.HeatEngineList{}
@@ -231,7 +231,7 @@ func (r *HeatEngineReconciler) SetupWithManager(mgr ctrl.Manager) error {
 						Namespace: o.GetNamespace(),
 						Name:      cr.Name,
 					}
-					r.Log.Info(fmt.Sprintf("ConfigMap object %s and CR %s marked with label: %s", o.GetName(), cr.Name, l))
+					r.Log.Info(fmt.Sprintf("secret object %s and CR %s marked with label: %s", o.GetName(), cr.Name, l))
 					result = append(result, reconcile.Request{NamespacedName: name})
 				}
 			}
@@ -244,8 +244,8 @@ func (r *HeatEngineReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&heatv1beta1.HeatEngine{}).
 		Owns(&appsv1.Deployment{}).
-		Watches(&corev1.ConfigMap{},
-			handler.EnqueueRequestsFromMapFunc(configMapFn)).
+		Watches(&corev1.Secret{},
+			handler.EnqueueRequestsFromMapFunc(secretFn)).
 		Watches(
 			&corev1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(r.findObjectsForSrc),


### PR DESCRIPTION
We trigger reconciles for each controllers based on different events. This can lead to a situation where Heat engine - which doesn't have the same number of events that will trigger a reconcile, becomes out of sync with the other controllers. For example, the configs which are essentially the same but updated with https endpoints can be synced by the HeatAPI and HeatCfnApi controllers first, before the HeatEngine controller finally catches up. In this interval of time the heat-engine process will fail since it's trying to speak to non https endpoints instead of the correct https ones.

Jira: https://issues.redhat.com/browse/OSPCIX-795