### PR TITLE
[golang] bump to golang 1.22

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: tools
   namespace: openstack-k8s-operators
-  tag: ci-build-root-golang-1.21-sdk-1.31
+  tag: ci-build-root-golang-1.22-sdk-1.31

--- a/.github/workflows/build-heat-operator.yaml
+++ b/.github/workflows/build-heat-operator.yaml
@@ -15,7 +15,7 @@ jobs:
     uses: openstack-k8s-operators/openstack-k8s-operators-ci/.github/workflows/reusable-build-operator.yaml@main
     with:
       operator_name: heat
-      go_version: 1.21.x
+      go_version: 1.22.x
       operator_sdk_version: 1.31.0
     secrets:
       IMAGENAMESPACE: ${{ secrets.IMAGENAMESPACE }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
       entry: bashate --error . --ignore=E006,E040,E011,E020,E012
 
 - repo: https://github.com/golangci/golangci-lint
-  rev: v1.59.1
+  rev: v1.63.4
   hooks:
     - id: golangci-lint-full
       args: ["-v"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-ARG GOLANG_BUILDER=registry.access.redhat.com/ubi9/go-toolset:1.21
+ARG GOLANG_BUILDER=registry.access.redhat.com/ubi9/go-toolset:1.22
 ARG OPERATOR_BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 FROM $GOLANG_BUILDER as builder

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ IMG ?= $(DEFAULT_IMG)
 ENVTEST_K8S_VERSION = 1.29
 
 # Set minimum Go version
-GOTOOLCHAIN_VERSION ?= go1.21.0
+GOTOOLCHAIN_VERSION ?= go1.22.0
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -120,9 +120,10 @@ tidy: ## Run go mod tidy on every mod file in the repo
 	go mod tidy
 	cd ./api && go mod tidy
 
+GOLANGCI_LINT_VERSION ?= v1.63.4
 .PHONY: golangci-lint
 golangci-lint:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.59.1
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s $(GOLANGCI_LINT_VERSION)
 	$(LOCALBIN)/golangci-lint run --fix --verbose
 
 PROCS?=$(shell expr $(shell nproc --ignore 2) / 2)

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/openstack-k8s-operators/heat-operator/api
 
-go 1.21
+go 1.22
 
 require (
 	github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20250422055748-825e3d94da81

--- a/controllers/heat_controller.go
+++ b/controllers/heat_controller.go
@@ -668,7 +668,7 @@ func (r *HeatReconciler) reconcileNormal(ctx context.Context, instance *heatv1be
 			heatv1beta1.HeatEngineReadyCondition,
 			condition.ErrorReason,
 			condition.SeverityWarning,
-			err.Error()))
+			"%s", err.Error()))
 		return ctrl.Result{}, err
 	}
 
@@ -680,7 +680,7 @@ func (r *HeatReconciler) reconcileNormal(ctx context.Context, instance *heatv1be
 			heatv1beta1.HeatEngineReadyCondition,
 			condition.ErrorReason,
 			condition.SeverityWarning,
-			err.Error()))
+			"%s", err.Error()))
 		return ctrl.Result{}, err
 	}
 	// Only mirror the underlying condition if the observedGeneration is

--- a/controllers/heatapi_controller.go
+++ b/controllers/heatapi_controller.go
@@ -664,7 +664,7 @@ func (r *HeatAPIReconciler) reconcileNormal(ctx context.Context, instance *heatv
 					condition.TLSInputReadyCondition,
 					condition.RequestedReason,
 					condition.SeverityInfo,
-					fmt.Sprintf(condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName)))
+					condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName))
 				return ctrl.Result{}, nil
 			}
 			instance.Status.Conditions.Set(condition.FalseCondition(
@@ -689,7 +689,7 @@ func (r *HeatAPIReconciler) reconcileNormal(ctx context.Context, instance *heatv
 				condition.TLSInputReadyCondition,
 				condition.RequestedReason,
 				condition.SeverityInfo,
-				fmt.Sprintf(condition.TLSInputReadyWaitingMessage, err.Error())))
+				condition.TLSInputReadyWaitingMessage, err.Error()))
 			return ctrl.Result{}, nil
 		}
 		instance.Status.Conditions.Set(condition.FalseCondition(

--- a/controllers/heatcfnapi_controller.go
+++ b/controllers/heatcfnapi_controller.go
@@ -665,7 +665,7 @@ func (r *HeatCfnAPIReconciler) reconcileNormal(ctx context.Context, instance *he
 					condition.TLSInputReadyCondition,
 					condition.RequestedReason,
 					condition.SeverityInfo,
-					fmt.Sprintf(condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName)))
+					condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName))
 				return ctrl.Result{}, nil
 			}
 			instance.Status.Conditions.Set(condition.FalseCondition(
@@ -690,7 +690,7 @@ func (r *HeatCfnAPIReconciler) reconcileNormal(ctx context.Context, instance *he
 				condition.TLSInputReadyCondition,
 				condition.RequestedReason,
 				condition.SeverityInfo,
-				fmt.Sprintf(condition.TLSInputReadyWaitingMessage, err.Error())))
+				condition.TLSInputReadyWaitingMessage, err.Error()))
 			return ctrl.Result{}, nil
 		}
 		instance.Status.Conditions.Set(condition.FalseCondition(

--- a/controllers/heatengine_controller.go
+++ b/controllers/heatengine_controller.go
@@ -416,7 +416,7 @@ func (r *HeatEngineReconciler) reconcileNormal(
 					condition.TLSInputReadyCondition,
 					condition.RequestedReason,
 					condition.SeverityInfo,
-					fmt.Sprintf(condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName)))
+					condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName))
 				return ctrl.Result{}, nil
 			}
 			instance.Status.Conditions.Set(condition.FalseCondition(

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openstack-k8s-operators/heat-operator
 
-go 1.21
+go 1.22
 
 replace github.com/openstack-k8s-operators/heat-operator/api => ./api
 


### PR DESCRIPTION
* bump in go.mod (base and api)
* bump go-toolset in Dockerfile
* bump in github jobs ('.github/workflows')
* Bump the golangci-lint version in the .pre-commit-config.yaml to v1.63.4
* Bump build_root_image in .ci-operator.yaml to ci-build-root-golang-1.22-sdk-1.31 (if set)

To test on existing env:
* update golang to 1.22
* delete current `go.work*` files
* init go work files `go work init`

Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/1051
Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/1411

Jira: [OSPRH-12935](https://issues.redhat.com//browse/OSPRH-12935)