### PR TITLE
Remove memcached_sasl_enabled=True workaround

### DIFF
--- a/templates/heat/config/00-default.conf
+++ b/templates/heat/config/00-default.conf
@@ -14,8 +14,6 @@ backend = oslo_cache.memcache_pool
 memcache_servers = {{ .MemcachedServers }}
 memcache_socket_timeout = 0.5
 memcache_pool_connection_get_timeout = 1
-# workaround to force bmemcache driver
-memcache_sasl_enabled = true
 {{else}}
 backend = dogpile.cache.memcached
 memcache_servers = {{ .MemcachedServersWithInet }}


### PR DESCRIPTION
Since https://review.opendev.org/c/openstack/oslo.cache/+/949978 is merged and backported to all the stable releases let's remove the workaround.
Patch was also cherry-picked to downstream antelope.

Jira: https://issues.redhat.com/browse/OSPRH-17029