### PR TITLE
Replace deprecated 'cifmw_test_operator_concurrency'

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -8,7 +8,7 @@
         - "@scenarios/centos-9/multinode-ci.yml"
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/heat-operator'].src_dir }}/ci/tempest/ci_fw_vars.yaml"
       cifmw_run_test_role: test_operator
-      cifmw_test_operator_concurrency: 4
+      cifmw_test_operator_tempest_concurrency: 4
       cifmw_test_operator_timeout: 7200
       cifmw_test_operator_tempest_network_attachments:
         - ctlplane


### PR DESCRIPTION
Replace deprecated 'cifmw_test_operator_concurrency' with 'cifmw_test_operator_tempest_concurrency'
This aligns with the DoD described in https://issues.redhat.com/browse/OSPRH-16755