### PR TITLE
Set service_type in [keystone_authtoken] for access rule validation

### DIFF
--- a/templates/heat/config/00-default.conf
+++ b/templates/heat/config/00-default.conf
@@ -106,6 +106,7 @@ memcached_servers={{ .MemcachedServers }}
 region_name=regionOne
 auth_url={{ .KeystoneInternalURL }}
 interface=internal
+service_type=orchestration
 {{if (index . "MemcachedAuthCert")}}
 memcache_tls_certfile = {{ .MemcachedAuthCert }}
 memcache_tls_keyfile = {{ .MemcachedAuthKey }}


### PR DESCRIPTION
Without service_type configured, keystonemiddleware cannot validate application credentials with custom access rules, causing HTTP 401 for end users.

Note: for heat-cfn users still need to use customServiceConfig.

Closes: [OSPRH-22365](https://redhat.atlassian.net/browse/OSPRH-22365)