### PR TITLE
Remove unnecessary pods RBAC permissions

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,7 +8,6 @@ rules:
   - ""
   resources:
   - configmaps
-  - pods
   - secrets
   - services
   verbs:

--- a/internal/controller/heat_controller.go
+++ b/internal/controller/heat_controller.go
@@ -168,7 +168,6 @@ var keystoneAPI *keystonev1.KeystoneAPI
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update;patch
 // service account permissions that are needed to grant permission to the above
 // +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid,resources=securitycontextconstraints,verbs=use
-// +kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -497,11 +496,6 @@ func (r *HeatReconciler) reconcileNormal(ctx context.Context, instance *heatv1be
 			ResourceNames: []string{"anyuid"},
 			Resources:     []string{"securitycontextconstraints"},
 			Verbs:         []string{"use"},
-		},
-		{
-			APIGroups: []string{""},
-			Resources: []string{"pods"},
-			Verbs:     []string{"create", "get", "list", "watch", "update", "patch", "delete"},
 		},
 	}
 	rbacResult, err := common_rbac.ReconcileRbac(ctx, helper, instance, rbacRules)


### PR DESCRIPTION
The workload rbacRules and kubebuilder RBAC markers granted the operator and its workload service account full CRUD (create/delete/get/list/patch/update/ watch) on core Pods, but the operator never reads or writes Pod objects directly — pods only ever come into being indirectly via Deployments/ StatefulSets/Jobs. Remove the unused pods permission and regenerate config/rbac/role.yaml.