### PR TITLE
Harden workload pod security context

### DIFF
--- a/internal/heat/funcs.go
+++ b/internal/heat/funcs.go
@@ -41,12 +41,14 @@ func GetHeatDBSecurityContext() *corev1.SecurityContext {
 
 // GetHeatSecurityContext returns the security context for heat services
 func GetHeatSecurityContext() *corev1.SecurityContext {
-	var runAsUser = HeatUID
-	var runAsGroup = HeatGID
+	trueVal := true
+	runAsUser := int64(HeatUID)
+	runAsGroup := int64(HeatGID)
 
 	return &corev1.SecurityContext{
-		RunAsUser:  &runAsUser,
-		RunAsGroup: &runAsGroup,
+		RunAsUser:    &runAsUser,
+		RunAsGroup:   &runAsGroup,
+		RunAsNonRoot: &trueVal,
 	}
 }
 

--- a/internal/heatapi/deployment.go
+++ b/internal/heatapi/deployment.go
@@ -96,7 +96,9 @@ func Deployment(
 						// httpd needs to have access to the certificates in /etc/pki/tls/certs/...
 						// setting the FSGroup results in everything mounted to the pod to have the
 						// heat group set, now the certs will be mounted
-						FSGroup: ptr.To(heat.HeatGID),
+						FSGroup:      ptr.To(heat.HeatGID),
+						RunAsGroup:   ptr.To(heat.HeatGID),
+						RunAsNonRoot: ptr.To(true),
 					},
 					Containers: []corev1.Container{
 						{

--- a/internal/heatcfnapi/deployment.go
+++ b/internal/heatcfnapi/deployment.go
@@ -96,7 +96,9 @@ func Deployment(
 						// httpd needs to have access to the certificates in /etc/pki/tls/certs/...
 						// setting the FSGroup results in everything mounted to the pod to have the
 						// heat group set, now the certs will be mounted
-						FSGroup: ptr.To(heat.HeatGID),
+						FSGroup:      ptr.To(heat.HeatGID),
+						RunAsGroup:   ptr.To(heat.HeatGID),
+						RunAsNonRoot: ptr.To(true),
 					},
 					Containers: []corev1.Container{
 						{

--- a/internal/heatengine/deployment.go
+++ b/internal/heatengine/deployment.go
@@ -95,7 +95,9 @@ func Deployment(instance *heatv1beta1.HeatEngine, configHash string, labels map[
 						// httpd needs to have access to the certificates in /etc/pki/tls/certs/...
 						// setting the FSGroup results in everything mounted to the pod to have the
 						// heat group set, now the certs will be mounted
-						FSGroup: ptr.To(heat.HeatGID),
+						FSGroup:      ptr.To(heat.HeatGID),
+						RunAsGroup:   ptr.To(heat.HeatGID),
+						RunAsNonRoot: ptr.To(true),
 					},
 					Containers: []corev1.Container{
 						{


### PR DESCRIPTION
Add RunAsNonRoot, RunAsGroup, and SeccompProfile: RuntimeDefault to all heat workload pods and containers while retaining the anyuid SCC required till we change container images to stop using kolla based privilege escalation.